### PR TITLE
fix(transport): cap inline frame size and expose TINYROS_MAX_FRAME_BYTES

### DIFF
--- a/docs/guides/architecture/transport.md
+++ b/docs/guides/architecture/transport.md
@@ -85,5 +85,12 @@ Each client runs:
 | Name | Meaning | Default |
 |---|---|---|
 | `TINYROS_SHM_THRESHOLD` | Payload size (bytes) above which ndarrays go via shm | `65536` |
+| `TINYROS_MAX_FRAME_BYTES` | Upper bound on inline frame body size; oversized headers are rejected without buffering | `268435456` (256 MiB) |
 
 Set `TINYROS_SHM_THRESHOLD=0` to force everything inline.
+
+Both limits can also be overridden per instance via the `shm_threshold`
+and `max_frame_bytes` kwargs on `TinyServer` / `TinyClient`. The frame
+cap only affects inline `CALL` and `REPLY` bodies; ndarrays that take
+the shared-memory side-channel send only small metadata on the socket
+and are unaffected.

--- a/src/tinyros/transport.py
+++ b/src/tinyros/transport.py
@@ -106,7 +106,7 @@ def _default_max_frame_bytes() -> int:
     if raw is None:
         return _DEFAULT_MAX_FRAME_BYTES
     try:
-        return max(_HEADER_SIZE, int(raw))
+        return max(0, int(raw))
     except ValueError:
         _logger.warning(
             f"TINYROS_MAX_FRAME_BYTES={raw!r} is not an integer; "
@@ -847,6 +847,7 @@ class TinyClient:
                         f"({length} bytes)"
                     )
                 )
+                self._shutdown_io()
                 return
             body = _recvall(self._sock, length, self._running.is_set) if length else b""
             if body is None:
@@ -914,6 +915,28 @@ class TinyClient:
         for fut in pending.values():
             if not fut.done():
                 fut.set_exception(exc)
+
+    def _shutdown_io(self) -> None:
+        """Release the socket and wake the send loop without joining threads.
+
+        Safe to call from a worker thread -- notably :meth:`_recv_loop`,
+        where joining sibling threads would self-deadlock. Idempotent,
+        so :meth:`close` can still run its full shutdown sequence
+        afterwards. Unlinks any shm blocks the send loop never got to.
+        """
+        try:
+            self._sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        try:
+            self._send_queue.put(_SENTINEL)
+        except (RuntimeError, ValueError):
+            pass
+        with self._pending_shm_lock:
+            stragglers = list(self._pending_shm)
+            self._pending_shm.clear()
+        for name in stragglers:
+            _try_unlink_shm(name)
 
     def close(self, timeout: float | None = 2.0) -> None:
         """Close the client and release resources.

--- a/src/tinyros/transport.py
+++ b/src/tinyros/transport.py
@@ -19,6 +19,13 @@ The shared-memory side-channel activates when the call argument is an
 ndarray whose ``nbytes`` is at least the configured threshold (default
 64 KiB, set via the ``TINYROS_SHM_THRESHOLD`` env var or the
 ``shm_threshold`` constructor kwarg; ``0`` disables the fast path).
+
+Inline frames (CALL without the shm path and every REPLY) are capped at
+``TINYROS_MAX_FRAME_BYTES`` bytes (default 256 MiB) so a misbehaving
+peer cannot force an unbounded allocation by claiming a huge length in
+the header. Override per-instance via the ``max_frame_bytes`` kwarg on
+:class:`TinyServer` / :class:`TinyClient`.
+
 The whole transport assumes a single host.
 
 See ``docs/guides/architecture/transport.md`` for the rationale behind
@@ -57,6 +64,7 @@ _HEADER_SIZE = struct.calcsize(_HEADER_FMT)
 
 _DEFAULT_SHM_THRESHOLD = 65536
 _DEFAULT_POOL_WORKERS = 32
+_DEFAULT_MAX_FRAME_BYTES = 256 * 1024 * 1024
 _ACCEPT_POLL_S = 0.1
 _READ_POLL_S = 1.0
 _CONNECT_TIMEOUT_S = 10.0
@@ -73,7 +81,38 @@ def _default_shm_threshold() -> int:
     raw = os.getenv("TINYROS_SHM_THRESHOLD")
     if raw is None:
         return _DEFAULT_SHM_THRESHOLD
-    return max(0, int(raw))
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        _logger.warning(
+            f"TINYROS_SHM_THRESHOLD={raw!r} is not an integer; "
+            f"falling back to default ({_DEFAULT_SHM_THRESHOLD})"
+        )
+        return _DEFAULT_SHM_THRESHOLD
+
+
+def _default_max_frame_bytes() -> int:
+    """Maximum inline frame body size in bytes (overridable via env).
+
+    Returns:
+        Upper bound the reader loops enforce on the ``length`` field of
+        the wire header. Frames claiming more are rejected without
+        buffering so a misbehaving peer cannot trigger an unbounded
+        allocation. Only affects inline CALL / REPLY payloads -- ndarrays
+        that take the shared-memory side-channel send only metadata on
+        the socket and are unaffected.
+    """
+    raw = os.getenv("TINYROS_MAX_FRAME_BYTES")
+    if raw is None:
+        return _DEFAULT_MAX_FRAME_BYTES
+    try:
+        return max(_HEADER_SIZE, int(raw))
+    except ValueError:
+        _logger.warning(
+            f"TINYROS_MAX_FRAME_BYTES={raw!r} is not an integer; "
+            f"falling back to default ({_DEFAULT_MAX_FRAME_BYTES})"
+        )
+        return _DEFAULT_MAX_FRAME_BYTES
 
 
 def _recvall(
@@ -296,6 +335,7 @@ class TinyServer:
         port: int,
         *,
         workers: int = _DEFAULT_POOL_WORKERS,
+        max_frame_bytes: int | None = None,
     ) -> None:
         """Initialize the server.
 
@@ -304,10 +344,19 @@ class TinyServer:
             host: Interface address to bind on.
             port: TCP port to bind on.
             workers: Maximum concurrent callback executions.
+            max_frame_bytes: Upper bound on inline frame body size. ``None``
+                uses ``TINYROS_MAX_FRAME_BYTES`` or the 256 MiB default.
+                Frames claiming more are rejected without buffering so a
+                misbehaving peer cannot trigger an unbounded allocation.
         """
         self.name = name
         self.host = host
         self.port = port
+        self._max_frame_bytes = (
+            max_frame_bytes
+            if max_frame_bytes is not None
+            else _default_max_frame_bytes()
+        )
         self._callbacks: dict[str, Callable[..., Any]] = {}
         self._pool = concurrent.futures.ThreadPoolExecutor(
             max_workers=workers,
@@ -439,6 +488,12 @@ class TinyServer:
                 if header is None:
                     return
                 kind, length = struct.unpack(_HEADER_FMT, header)
+                if length > self._max_frame_bytes:
+                    _logger.warning(
+                        f"{self.name}: oversized frame ({length} bytes, "
+                        f"max {self._max_frame_bytes}); dropping connection"
+                    )
+                    return
                 body = _recvall(conn, length, self._running.is_set) if length else b""
                 if body is None:
                     return
@@ -575,6 +630,7 @@ class TinyClient:
         name: str,
         *,
         shm_threshold: int | None = None,
+        max_frame_bytes: int | None = None,
         connect_timeout: float = _CONNECT_TIMEOUT_S,
     ) -> None:
         """Initialize the client and connect to the server.
@@ -587,6 +643,10 @@ class TinyClient:
                 arguments travel through shared memory. ``None`` uses
                 ``TINYROS_SHM_THRESHOLD`` or the 64 KiB default. ``0``
                 disables the shm fast path.
+            max_frame_bytes: Upper bound on inline reply body size. ``None``
+                uses ``TINYROS_MAX_FRAME_BYTES`` or the 256 MiB default.
+                Reply frames claiming more tear the client down instead of
+                buffering.
             connect_timeout: Max seconds to wait for the server to accept
                 the connection.
         """
@@ -595,6 +655,11 @@ class TinyClient:
         self.name = name
         self._shm_threshold = (
             shm_threshold if shm_threshold is not None else _default_shm_threshold()
+        )
+        self._max_frame_bytes = (
+            max_frame_bytes
+            if max_frame_bytes is not None
+            else _default_max_frame_bytes()
         )
         self._sock = self._connect(connect_timeout)
         self._sock.settimeout(_READ_POLL_S)
@@ -771,6 +836,18 @@ class TinyClient:
                     )
                 return
             kind, length = struct.unpack(_HEADER_FMT, header)
+            if length > self._max_frame_bytes:
+                _logger.warning(
+                    f"{self.name}: oversized reply frame ({length} bytes, "
+                    f"max {self._max_frame_bytes}); tearing down"
+                )
+                self._fail_all_pending(
+                    ConnectionError(
+                        f"tinyros client {self.name!r}: oversized reply "
+                        f"({length} bytes)"
+                    )
+                )
+                return
             body = _recvall(self._sock, length, self._running.is_set) if length else b""
             if body is None:
                 if self._running.is_set():

--- a/tests/test_transport_rpc.py
+++ b/tests/test_transport_rpc.py
@@ -306,9 +306,9 @@ def test_1mp_image_roundtrips_via_shm(
     img = rng.integers(0, 256, size=(1024, 1024, 3), dtype=np.uint8)
     expected = int(img.sum())
     fut = client.call("checksum", img)
-    assert fut.result(timeout=3.0) == expected, (
-        "1 MP image should round-trip through shm with bit-identical content"
-    )
+    assert (
+        fut.result(timeout=3.0) == expected
+    ), "1 MP image should round-trip through shm with bit-identical content"
 
 
 def test_call_after_close_fails_cleanly(free_port: int) -> None:

--- a/tests/test_transport_rpc.py
+++ b/tests/test_transport_rpc.py
@@ -264,6 +264,56 @@ def test_oversized_frame_header_drops_connection(free_port: int) -> None:
         wait_port_free(free_port)
 
 
+def test_client_drops_on_oversized_reply_header(free_port: int) -> None:
+    """A malicious/buggy server sending an oversized REPLY header tears
+    the client down: pending futures fail fast and the send thread exits.
+    """
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", free_port))
+    listener.listen(1)
+    accepted: list[socket.socket] = []
+    ready = threading.Event()
+
+    def accept_once() -> None:
+        conn, _ = listener.accept()
+        accepted.append(conn)
+        ready.set()
+
+    acceptor = threading.Thread(target=accept_once, daemon=True)
+    acceptor.start()
+
+    client = TinyClient(host="127.0.0.1", port=free_port, name="t-victim")
+    try:
+        assert ready.wait(timeout=2.0), "fake server should accept the client"
+        peer = accepted[0]
+        fut = client.call("echo", "hi")
+        # _MSG_REPLY = 3; length = 2**32 - 1 is absurd and must be rejected.
+        peer.sendall(struct.pack("!BI", 3, 2**32 - 1))
+        with pytest.raises(ConnectionError):
+            fut.result(timeout=2.0)
+        deadline = time.monotonic() + 2.0
+        while (
+            client._send_thread.is_alive()  # noqa: SLF001
+            and time.monotonic() < deadline
+        ):
+            time.sleep(0.01)
+        assert (
+            not client._send_thread.is_alive()
+        ), (  # noqa: SLF001
+            "send thread should exit after the recv loop tears down the client"
+        )
+    finally:
+        for s in accepted:
+            try:
+                s.close()
+            except OSError:
+                pass
+        listener.close()
+        client.close(timeout=1.0)
+        wait_port_free(free_port)
+
+
 def test_max_frame_bytes_kwarg_tightens_cap(free_port: int) -> None:
     """A constructor-level cap overrides the module default."""
     server = TinyServer(

--- a/tests/test_transport_rpc.py
+++ b/tests/test_transport_rpc.py
@@ -8,6 +8,7 @@ and that shutdown releases the port.
 from __future__ import annotations
 
 import socket
+import struct
 import threading
 import time
 from collections.abc import Iterator
@@ -234,6 +235,80 @@ def test_shutdown_releases_blocked_reader(free_port: int) -> None:
     finally:
         raw.close()
         wait_port_free(free_port)
+
+
+def test_oversized_frame_header_drops_connection(free_port: int) -> None:
+    """A peer claiming an absurd frame length is disconnected, not buffered.
+
+    Without a cap the reader would loop inside ``_recvall`` for gigabytes
+    of data the peer never intends to send, tying up the connection and
+    inviting a trivial resource exhaustion.
+    """
+    server = TinyServer(name="t-cap", host="127.0.0.1", port=free_port)
+    server.start(block=False)
+    raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    raw.connect(("127.0.0.1", free_port))
+    try:
+        # CALL kind (1) with length = 2^32-1: no legitimate frame is this big.
+        header = struct.pack("!BI", 1, 2**32 - 1)
+        raw.sendall(header)
+        raw.settimeout(2.0)
+        data = raw.recv(1)
+        assert data == b"", (
+            f"server should close the connection on an oversized frame; "
+            f"got {data!r} instead of EOF"
+        )
+    finally:
+        raw.close()
+        server.close(timeout=1.0)
+        wait_port_free(free_port)
+
+
+def test_max_frame_bytes_kwarg_tightens_cap(free_port: int) -> None:
+    """A constructor-level cap overrides the module default."""
+    server = TinyServer(
+        name="t-cap-kwarg",
+        host="127.0.0.1",
+        port=free_port,
+        max_frame_bytes=1024,
+    )
+    server.start(block=False)
+    raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    raw.connect(("127.0.0.1", free_port))
+    try:
+        # Frame claims 2 KiB, well under the module default but above our kwarg.
+        header = struct.pack("!BI", 1, 2048)
+        raw.sendall(header)
+        raw.settimeout(2.0)
+        data = raw.recv(1)
+        assert data == b"", (
+            f"server with max_frame_bytes=1024 should drop a 2 KiB frame; "
+            f"got {data!r}"
+        )
+    finally:
+        raw.close()
+        server.close(timeout=1.0)
+        wait_port_free(free_port)
+
+
+def test_1mp_image_roundtrips_via_shm(
+    server_client_pair: tuple[TinyServer, TinyClient, int],
+) -> None:
+    """A 1 MP RGB image (~3 MB) round-trips unchanged through the shm path.
+
+    Regression guard: the frame cap must not interfere with real image
+    payloads, which take the shm side-channel and put only metadata on
+    the wire.
+    """
+    _server, client, _ = server_client_pair
+    _server.bind("checksum", lambda arr: int(arr.sum()))
+    rng = np.random.default_rng(42)
+    img = rng.integers(0, 256, size=(1024, 1024, 3), dtype=np.uint8)
+    expected = int(img.sum())
+    fut = client.call("checksum", img)
+    assert fut.result(timeout=3.0) == expected, (
+        "1 MP image should round-trip through shm with bit-identical content"
+    )
 
 
 def test_call_after_close_fails_cleanly(free_port: int) -> None:


### PR DESCRIPTION
## Summary

- Cap inline frame bodies at 256 MiB by default; reject oversized headers without buffering. Prevents the trivial DoS where a peer claims a 4 GiB frame and pins the reader inside `_recvall` forever.
- Expose the cap as `TINYROS_MAX_FRAME_BYTES` env var and `max_frame_bytes` kwarg on `TinyServer` / `TinyClient`, matching the existing `shm_threshold` pattern.
- Client now fails all pending futures on an oversized reply so callers don't hang.
- Drive-by: `_default_shm_threshold` falls back to the default with a warning on a malformed env var instead of crashing the constructor.

The cap applies only to inline `CALL` / `REPLY` bodies; ndarrays that take the shared-memory side-channel send only metadata on the socket and are unaffected — 1 MP+ images continue to round-trip fine.

Closes #7

## Test plan

- [x] New test `test_oversized_frame_header_drops_connection`: raw socket sends a header with `length = 2**32-1`; asserts the server closes the connection rather than buffering 4 GiB. Fails on HEAD, passes with the cap.
- [x] New test `test_max_frame_bytes_kwarg_tightens_cap`: constructor-level override rejects a 2 KiB frame that would pass the default.
- [x] New test `test_1mp_image_roundtrips_via_shm`: 1 MP RGB image (~3 MB) survives the cap via the shm path.
- [x] Existing suite: `uv run pytest` → 43 passed, 89 skipped.
- [x] Lint / type: `uv run pre-commit run --all-files` and `--hook-stage push --all-files` clean.
- [x] Benchmark: `pytest -m run_explicitly tests/benchmark/tinyros/test_speed_interprocess.py` → 2000/2000 delivered on every payload, p50 0.25 ms (small) → 1.42 ms (4 MiB); no regression from the cap check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
