### PR TITLE
docs(transport): fix CALL body format and clarify single-arg dispatch

### DIFF
--- a/docs/guides/architecture/transport.md
+++ b/docs/guides/architecture/transport.md
@@ -18,13 +18,21 @@ Kinds:
 
 | Kind | Meaning |
 |---|---|
-| `CALL` | RPC call: body is pickled `(cb_name, args_tuple, req_id)` |
-| `CALL_LARGE` | RPC call whose payload went through shared memory |
+| `CALL` | RPC call: body is pickled `(req_id, cb_name, arg)` |
+| `CALL_LARGE` | RPC call whose single-ndarray payload travels through shared memory; body is a pickled metadata dict (see below) |
 | `REPLY` | Response to an RPC: body is pickled `(req_id, ok, payload_or_exc)` |
 | `BYE` | Client announces graceful disconnect |
 
-The body uses **pickle protocol 5 with out-of-band buffers** so numpy
-payloads do not get copied into the main pickle stream.
+`arg` is a single positional value — the transport does not carry
+`*args` / `**kwargs`. Callbacks bound via `TinyServer.bind` are invoked
+as `fn(arg)`.
+
+The `CALL` body uses **pickle protocol 5 with out-of-band buffers** so
+numpy payloads embedded inside `arg` do not get copied into the main
+pickle stream. The `CALL_LARGE` body is a plain pickle of the metadata
+dict `{"req_id", "cb_name", "shm_name", "dtype", "shape", "nbytes"}`;
+the ndarray itself travels through the shared-memory block named by
+`shm_name`.
 
 ## Shared-memory fast path
 


### PR DESCRIPTION
## Summary

- Fix the `CALL` body format in `docs/guides/architecture/transport.md`: the doc listed `(cb_name, args_tuple, req_id)`, but the code has always packed `(req_id, cb_name, arg)` with a single positional value.
- Clarify that `arg` is a single value — the transport does not carry `*args` / `**kwargs`.
- Flesh out the `CALL_LARGE` row with the actual metadata fields (`shm_name`, `dtype`, `shape`, `nbytes`) so readers can line the doc up against `_pack_call_large`.

Doc-only change; no code touched.

Closes #17

## Test plan

- [x] `uv run pre-commit run --all-files` clean.
- [x] Cross-checked against `_pack_oob` in `src/tinyros/transport.py` (`(req_id, method, arg)`) and `_pack_call_large` (keys: `req_id`, `cb_name`, `shm_name`, `dtype`, `shape`, `nbytes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
