### PR TITLE
fix(transport): fail pending futures when client send fails

### DIFF
--- a/src/tinyros/transport.py
+++ b/src/tinyros/transport.py
@@ -752,6 +752,13 @@ class TinyClient:
             req_id = self._next_req_id
             self._next_req_id += 1
         with self._pending_lock:
+            if not self._running.is_set():
+                fut.set_exception(
+                    ConnectionError(
+                        f"tinyros client {self.name!r} is no longer running"
+                    )
+                )
+                return fut
             self._pending[req_id] = fut
         try:
             frame, shm_name = self._encode_call(req_id, method, arg)
@@ -815,7 +822,12 @@ class TinyClient:
                 self._sock.sendall(frame)
             except OSError as exc:
                 _logger.warning(f"{self.name}: send failed ({exc}); tearing down")
-                self._fail_pending(shm_name)
+                self._fail_all_pending(
+                    ConnectionError(
+                        f"tinyros client {self.name!r}: send failed ({exc})"
+                    )
+                )
+                self._shutdown_io()
                 return
             else:
                 if shm_name is not None:
@@ -876,40 +888,14 @@ class TinyClient:
                     else RuntimeError(str(result))
                 )
 
-    def _fail_pending(self, shm_name: str | None) -> None:
-        """Fail one send item and mark the client unusable.
-
-        Args:
-            shm_name: Shared-memory block name for the failing send
-                (if any).
-        """
-        self._running.clear()
-        names: list[str] = []
-        if shm_name is not None:
-            names.append(shm_name)
-        while True:
-            try:
-                item = self._send_queue.get_nowait()
-            except queue.Empty:
-                break
-            if item is _SENTINEL:
-                continue
-            if isinstance(item, tuple) and item[1] is not None:
-                names.append(item[1])
-        for n in names:
-            _try_unlink_shm(n)
-        with self._pending_shm_lock:
-            for n in names:
-                self._pending_shm.discard(n)
-
     def _fail_all_pending(self, exc: BaseException) -> None:
         """Resolve every outstanding future with an exception.
 
         Args:
             exc: Exception to set on each pending future.
         """
-        self._running.clear()
         with self._pending_lock:
+            self._running.clear()
             pending = dict(self._pending)
             self._pending.clear()
         for fut in pending.values():

--- a/tests/test_transport_rpc.py
+++ b/tests/test_transport_rpc.py
@@ -7,6 +7,7 @@ and that shutdown releases the port.
 
 from __future__ import annotations
 
+import concurrent.futures
 import socket
 import struct
 import threading
@@ -260,6 +261,92 @@ def test_oversized_frame_header_drops_connection(free_port: int) -> None:
         )
     finally:
         raw.close()
+        server.close(timeout=1.0)
+        wait_port_free(free_port)
+
+
+def test_pending_futures_fail_on_send_failure(free_port: int) -> None:
+    """When ``_send_loop`` hits ``OSError``, every pending future must
+    resolve with ``ConnectionError`` rather than hang.
+
+    Prior to the fix, the send loop cleared ``_running`` and returned
+    without failing per-request futures; ``_recv_loop``'s fail-pending
+    branch was gated on ``_running``, so pending futures stayed
+    unresolved. Exercises the send/recv race over ``iterations`` runs
+    so flakes in one direction are caught — whoever notices the dead
+    socket first, every future must fail cleanly.
+    """
+    iterations = 25
+    in_flight = 5
+    for i in range(iterations):
+        server = TinyServer(name=f"t-sf-srv-{i}", host="127.0.0.1", port=free_port)
+        server.bind("noop", lambda _x: None)
+        server.start(block=False)
+        client = TinyClient(host="127.0.0.1", port=free_port, name=f"t-sf-cli-{i}")
+        try:
+            # Break the write side of the client's socket so the next
+            # sendall raises BrokenPipeError immediately. This biases
+            # the send loop to lose the race with recv, which is the
+            # path the original bug lived on.
+            client._sock.shutdown(socket.SHUT_WR)  # noqa: SLF001
+            futures = [client.call("noop", j) for j in range(in_flight)]
+            for fut in futures:
+                with pytest.raises(ConnectionError):
+                    fut.result(timeout=2.0)
+        finally:
+            client.close(timeout=1.0)
+            server.close(timeout=1.0)
+            wait_port_free(free_port)
+
+
+def test_call_racing_teardown_does_not_hang(free_port: int) -> None:
+    """A ``call()`` racing with ``_fail_all_pending`` must not leak a future.
+
+    The early ``_running`` check in ``call()`` is not enough on its own:
+    without re-checking under ``_pending_lock``, a call can pass the
+    gate, be preempted, and insert into ``_pending`` after teardown has
+    already drained the map — leaving that future orphaned. ``call()``
+    must re-verify ``_running`` under the same lock it uses to insert,
+    and ``_fail_all_pending`` must clear ``_running`` under that lock.
+
+    Drive the interleaving deterministically: hold ``_pending_lock``
+    from the test thread, kick a ``call()`` on a worker (which will
+    pass the fast-path check and then block on the lock), then clear
+    ``_running`` and release. The only gate that can still save the
+    future is the re-check this fix adds inside the critical section.
+    """
+    server = TinyServer(name="t-race-srv", host="127.0.0.1", port=free_port)
+    server.bind("noop", lambda _x: None)
+    server.start(block=False)
+    client = TinyClient(host="127.0.0.1", port=free_port, name="t-race-cli")
+    try:
+        result: dict[str, concurrent.futures.Future] = {}
+        worker_ready = threading.Event()
+
+        def _caller() -> None:
+            worker_ready.set()
+            result["fut"] = client.call("noop", 1)
+
+        with client._pending_lock:  # noqa: SLF001
+            t = threading.Thread(target=_caller, daemon=True)
+            t.start()
+            # Give the worker time to pass the fast-path `is_set()`
+            # check and land on the contended `_pending_lock`.
+            assert worker_ready.wait(timeout=1.0)
+            time.sleep(0.05)
+            client._running.clear()  # noqa: SLF001
+        t.join(timeout=1.0)
+        assert not t.is_alive(), "worker call() must not hang on teardown"
+        fut = result["fut"]
+        with pytest.raises(ConnectionError):
+            fut.result(timeout=1.0)
+        with client._pending_lock:  # noqa: SLF001
+            assert client._pending == {}, (  # noqa: SLF001
+                "call() must not leave an entry in _pending once "
+                "_running has been cleared under the lock"
+            )
+    finally:
+        client.close(timeout=1.0)
         server.close(timeout=1.0)
         wait_port_free(free_port)
 


### PR DESCRIPTION
## Summary

- When `TinyClient._send_loop` hit `OSError` (peer died, broken pipe, RST), the old `_fail_pending` helper cleared `_running` and drained shm blocks but **never failed the per-request futures**. Because `_recv_loop`'s fail-pending branch is gated on `_running.is_set()`, recv would then skip the cleanup too. Result: every outstanding `Future` stayed unresolved forever whenever send lost the race to notice a dead socket.
- Replace `_fail_pending` with `_fail_all_pending(ConnectionError(...))` + `_shutdown_io()` directly in the send loop's error path — symmetric with how the recv loop already handles an oversized reply (from PR #20).
- `_shutdown_io` already reaps straggling shm blocks in `_pending_shm`, so the old helper is dead and has been removed.

Closes #5

## Test plan

- [x] New test `test_pending_futures_fail_on_send_failure` runs **25 iterations**. Each: shuts down the client's write side (`socket.SHUT_WR`) to bias the send/recv race toward send losing, issues 5 in-flight calls, and asserts every future resolves with `ConnectionError` within 2 s. Without the fix, each iteration would hit the 2 s timeout 5 times (125 × total).
- [x] Existing suite: `uv run pytest` → 45 passed, 89 skipped.
- [x] Lint / type: `uv run pre-commit run --all-files` and `--hook-stage push --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
