### PR TITLE
fix(transport): stop losing REPLY when callback exception is unpicklable

### DIFF
--- a/src/tinyros/transport.py
+++ b/src/tinyros/transport.py
@@ -547,7 +547,25 @@ class TinyServer:
             except Exception as exc:
                 ok = False
                 result = exc
-        body = _pack_oob((call.req_id, ok, result))
+        try:
+            body = _pack_oob((call.req_id, ok, result))
+        except Exception as pickle_exc:
+            _logger.warning(
+                f"{self.name}: reply for {call.cb_name!r} "
+                f"(req_id={call.req_id}) is not picklable ({pickle_exc}); "
+                f"substituting a RuntimeError so the caller does not hang"
+            )
+            body = _pack_oob(
+                (
+                    call.req_id,
+                    False,
+                    RuntimeError(
+                        f"tinyros server {self.name!r}: reply for "
+                        f"{call.cb_name!r} is not serializable "
+                        f"({type(result).__name__}: {pickle_exc})"
+                    ),
+                )
+            )
         frame = _frame(_MSG_REPLY, body)
         lock = self._conn_send_locks.get(id(call.conn))
         if lock is None:

--- a/tests/test_transport_rpc.py
+++ b/tests/test_transport_rpc.py
@@ -96,6 +96,34 @@ def test_remote_exception_propagates(
         fut.result(timeout=2.0)
 
 
+def test_unpicklable_exception_resolves_future(
+    server_client_pair: tuple[TinyServer, TinyClient, int],
+) -> None:
+    """A callback raising an exception whose args are not picklable must
+    not hang the client.
+
+    Before the fix, ``_pack_oob((req_id, False, exc))`` raised inside the
+    worker thread; no REPLY was sent; the future stayed unresolved
+    forever. After: the server logs the pickle failure, substitutes a
+    ``RuntimeError`` describing the original result type, and the caller
+    gets a bounded-time resolution.
+    """
+    server, client, _ = server_client_pair
+
+    def boom(_: object) -> None:
+        # A threading.Lock in the exception args is not picklable;
+        # pickle.dumps raises TypeError while serializing the tuple.
+        raise RuntimeError("synthetic", threading.Lock())
+
+    server.bind("boom", boom)
+    fut = client.call("boom", None)
+    with pytest.raises(RuntimeError) as excinfo:
+        fut.result(timeout=2.0)
+    assert "not serializable" in str(excinfo.value), (
+        f"fallback message should mention the pickle failure; " f"got {excinfo.value!r}"
+    )
+
+
 def test_unknown_method_raises_on_client(
     server_client_pair: tuple[TinyServer, TinyClient, int],
 ) -> None:


### PR DESCRIPTION
## Summary

- `TinyServer._execute_call` packed the reply tuple without guarding `_pack_oob`, so any callback whose exception (or successful return value) could not be pickled — e.g. an exception whose args contain a lambda, open socket, or `threading.Lock` — crashed the worker thread inside `pickle.dumps`. No REPLY ever left the server, and the caller's future stayed unresolved forever.
- Guard the pack step. On pickle failure, log a warning and send a fallback `RuntimeError` that names the original result type and the underlying pickle error. The caller still gets a bounded-time resolution and enough detail to fix the source.

Closes #6

## PR train

Stacked on **#22** (`fix/pending-futures-on-send-failure`). The base branch for this PR is set to that branch; when #22 merges, GitHub will retarget this PR to `main` automatically.

## Test plan

- [x] New test `test_unpicklable_exception_resolves_future`: callback raises `RuntimeError("synthetic", threading.Lock())` — `threading.Lock` is not picklable, so `pickle.dumps` of the exception tuple raises `TypeError`. Asserts the client's future resolves with a `RuntimeError` whose message mentions "not serializable" within 2 s. Fails on HEAD with a timeout.
- [x] Existing suite: `uv run pytest` → 46 passed, 89 skipped.
- [x] Lint / type: `uv run pre-commit run --all-files` and `--hook-stage push --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
