### PR TITLE
fix(node): raise on missing or non-callable subscription callback

### DIFF
--- a/src/tinyros/node.py
+++ b/src/tinyros/node.py
@@ -222,18 +222,41 @@ class TinyNode:
         )
 
     def _setup_subscriptions(self) -> None:
-        """Bind server callbacks for topics this node subscribes to."""
+        """Bind server callbacks for topics this node subscribes to.
+
+        Raises:
+            ValueError: If the config names a callback that is missing
+                on the subclass or resolves to a non-callable attribute.
+                Fails loudly at ``__init__`` time so a typo in
+                ``network_config.yaml`` cannot silently leave a
+                subscription unhandled at runtime.
+        """
         subscribed_topics = self.network_config.get_subscribers_for_node(self.name)
+        # Sentinel so we distinguish "attribute is missing" from
+        # "attribute exists but the subclass shadowed it with None"
+        # (e.g., ``some_cb = None`` as a placeholder). Using ``None``
+        # as the default would conflate the two and blame the user for
+        # a typo when the real issue is a non-callable shadow.
+        _missing = object()
         for topic_name, callback_name in subscribed_topics.items():
-            if hasattr(self, callback_name):
-                self.server.bind(callback_name, getattr(self, callback_name))
-                _logger.info(
-                    f"{self.name}: bound '{callback_name}' " f"for topic '{topic_name}'"
+            attr = getattr(self, callback_name, _missing)
+            if attr is _missing:
+                raise ValueError(
+                    f"{self.name}: network config subscribes topic "
+                    f"'{topic_name}' to callback '{callback_name}', "
+                    f"but no such method is defined on "
+                    f"{type(self).__name__}"
                 )
-            else:
-                _logger.error(
-                    f"{self.name}: callback method " f"'{callback_name}' not found"
+            if not callable(attr):
+                raise ValueError(
+                    f"{self.name}: attribute '{callback_name}' "
+                    f"(bound to topic '{topic_name}') is "
+                    f"{type(attr).__name__}, not callable"
                 )
+            self.server.bind(callback_name, attr)
+            _logger.info(
+                f"{self.name}: bound '{callback_name}' " f"for topic '{topic_name}'"
+            )
 
     def publish(self, topic: str, message: Any) -> list[concurrent.futures.Future]:
         """Publish ``message`` to every subscriber of ``topic``.

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -200,6 +200,77 @@ def test_init_rejects_unknown_node_name(
         TinyNode("ghost", cfg, bind_host="127.0.0.1")
 
 
+def test_init_rejects_missing_subscription_callback(
+    three_free_ports: list[int],
+) -> None:
+    """A subscription naming a method that doesn't exist fails at init.
+
+    Previously this was a silent log-and-continue; a typo in
+    ``network_config.yaml`` left the subscriber bound to nothing and the
+    publisher's messages vanished without trace. Loud failure lets the
+    operator fix the config before anything starts running.
+    """
+    cfg = _make_config(_ports(three_free_ports))
+    sub_port = three_free_ports[1]
+    try:
+        with pytest.raises(ValueError, match="on_topic"):
+            # Bare TinyNode has no ``on_topic`` method, but the config
+            # wires sub_a to invoke ``on_topic`` — init must reject this.
+            TinyNode("sub_a", cfg, bind_host="127.0.0.1")
+    finally:
+        wait_port_free(sub_port)
+
+
+class _ShadowedCallback(TinyNode):
+    """Subclass that shadows the configured callback name with a value."""
+
+    on_topic = "not a method"  # type: ignore[assignment]
+
+
+class _NoneShadowedCallback(TinyNode):
+    """Subclass that shadows the callback name with ``None``.
+
+    Guards against conflating ``getattr(..., None)`` returning ``None``
+    because the attribute is missing with ``None`` being the attribute
+    itself. The two failure modes need different error messages.
+    """
+
+    on_topic = None  # type: ignore[assignment]
+
+
+def test_init_rejects_non_callable_callback(
+    three_free_ports: list[int],
+) -> None:
+    """If the callback name resolves to a non-callable attribute, raise."""
+    cfg = _make_config(_ports(three_free_ports))
+    sub_port = three_free_ports[1]
+    try:
+        with pytest.raises(ValueError, match="not callable"):
+            _ShadowedCallback("sub_a", cfg, bind_host="127.0.0.1")
+    finally:
+        wait_port_free(sub_port)
+
+
+def test_init_distinguishes_missing_from_none_shadow(
+    three_free_ports: list[int],
+) -> None:
+    """A ``None``-valued attribute must report "not callable", not "missing".
+
+    The original implementation used ``getattr(self, name, None)`` and
+    branched on ``attr is None``, which conflates "no such attribute"
+    (the common typo path) with "attribute exists but is ``None``" (a
+    subclass placeholder or an accidental ``= None``). Use a sentinel
+    default so the two surfaces tell the operator which one they hit.
+    """
+    cfg = _make_config(_ports(three_free_ports))
+    sub_port = three_free_ports[1]
+    try:
+        with pytest.raises(ValueError, match="NoneType.*not callable"):
+            _NoneShadowedCallback("sub_a", cfg, bind_host="127.0.0.1")
+    finally:
+        wait_port_free(sub_port)
+
+
 class _Boomer(TinyNode):
     """Subscriber whose callback always raises."""
 
@@ -251,12 +322,13 @@ def test_context_manager_shuts_down_on_exit(
 ) -> None:
     """``with TinyNode(...) as n:`` releases the port on block exit.
 
-    We pick ``sub_a`` because it only binds a listener and has no
-    outbound publishing in the test topology -- the context-manager
-    contract is independent of whether the node publishes.
+    We use ``sub_a`` via :class:`_Recorder` because the topology wires
+    it to the ``on_topic`` callback — the context-manager contract is
+    independent of whether the node publishes, but ``__init__`` still
+    verifies every declared subscription resolves to a real method.
     """
     cfg = _make_config(_ports(three_free_ports))
     sub_a_port = three_free_ports[1]
-    with TinyNode("sub_a", cfg, bind_host="127.0.0.1"):
+    with _Recorder("sub_a", cfg):
         pass
     wait_port_free(sub_a_port)


### PR DESCRIPTION
## Summary

- `TinyNode._setup_subscriptions` used to log an error and continue when a subscription named a callback that did not exist on the subclass. A typo in `network_config.yaml` (`cb_name: on_toipc` vs `on_topic`) then silently left the subscriber bound to nothing: publishers still published, but nothing processed the message. Very hard to diagnose from runtime symptoms alone.
- Fail loudly at `__init__`: raise `ValueError` when the attribute is missing, and also when it resolves to a non-callable (so a value that shadows the method name — `on_topic = "value"` — also fails).
- One existing test (`test_context_manager_shuts_down_on_exit`) relied on the silent-degradation behavior. Updated it to use `_Recorder`, which actually implements the bound callback.

## Breaking change

Nodes whose configs reference callbacks not defined on their subclass will now error at `__init__` instead of running with broken subscriptions. No legitimate code should rely on the old silent behavior.

Closes #13

## Test plan

- [x] New test `test_init_rejects_missing_subscription_callback`: bare `TinyNode` as `sub_a` (no `on_topic`) raises `ValueError` with the callback name in the message.
- [x] New test `test_init_rejects_non_callable_callback`: subclass that shadows `on_topic` with a string value raises `ValueError` with "not callable".
- [x] Existing test `test_context_manager_shuts_down_on_exit` now uses `_Recorder`; still green.
- [x] Existing suite: `uv run pytest` → 46 passed, 89 skipped.
- [x] Lint / type: `uv run pre-commit run --all-files` and `--hook-stage push --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
