### PR TITLE
refactor(node): drop unreachable except in publish; log fast-fail futures

### DIFF
--- a/src/tinyros/node.py
+++ b/src/tinyros/node.py
@@ -261,27 +261,44 @@ class TinyNode:
     def publish(self, topic: str, message: Any) -> list[concurrent.futures.Future]:
         """Publish ``message`` to every subscriber of ``topic``.
 
+        Never raises synchronously. :meth:`TinyClient.call` always
+        returns a future with any transport error already set on it, so
+        callers must inspect each returned future to observe delivery
+        or callback failures. When a subscriber's client is already
+        torn down the future resolves immediately; the failure is
+        logged here for visibility but the future is still returned so
+        the caller's control flow is identical across sync and async
+        failure paths.
+
         Args:
             topic: Topic name declared in the network config.
             message: Payload forwarded to each subscriber's callback.
 
         Returns:
             One future per subscriber, resolving with the callback's
-            return value (typically ``None``). An empty list is
-            returned when ``topic`` has no subscribers -- no error
-            is raised so publishers can run before their consumers
-            connect.
+            return value (typically ``None``) or with a transport /
+            encoding / remote exception (``ConnectionError`` when the
+            socket is down, ``pickle.PicklingError`` or similar when
+            ``_encode_call`` fails, or whatever the subscriber's
+            callback raised). An empty list is returned when ``topic``
+            has no subscribers -- no error is raised so publishers can
+            run before their consumers connect.
         """
         if topic not in self.topic_calls:
             _logger.warning(f"{self.name}: no subscribers for '{topic}'")
             return []
         futures: list[concurrent.futures.Future] = []
         for client_key, cb_name in self.topic_calls[topic]:
-            try:
-                client = self.clients[client_key]
-                futures.append(client.call(cb_name, message))
-            except (ConnectionError, OSError, RuntimeError) as exc:
-                _logger.error(f"{self.name}: failed to send message - {exc}")
+            fut = self.clients[client_key].call(cb_name, message)
+            if fut.done():
+                exc = fut.exception()
+                if exc is not None:
+                    _logger.warning(
+                        f"{self.name}: immediate failure publishing "
+                        f"'{topic}' -> {cb_name} on {client_key}: "
+                        f"{exc}"
+                    )
+            futures.append(fut)
         return futures
 
     def shutdown(self) -> None:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -317,6 +317,40 @@ def test_callback_exception_surfaces_on_publisher_future(
             wait_port_free(p)
 
 
+def test_publish_returns_failed_future_for_closed_client(
+    three_free_ports: list[int],
+) -> None:
+    """``publish()`` must not raise when a subscriber's client is torn
+    down -- it returns an already-failed future instead, matching the
+    async failure path.
+    """
+    cfg = _make_config(_ports(three_free_ports))
+    sub_a = _Recorder("sub_a", cfg)
+    sub_b = _Recorder("sub_b", cfg)
+    pub = TinyNode("pub", cfg, bind_host="127.0.0.1")
+    try:
+        for client in pub.clients.values():
+            client.close(timeout=1.0)
+        futures = pub.publish("topic", "hi")
+        assert len(futures) == 2, (
+            f"publish should still return one future per subscriber "
+            f"when clients are closed; got {len(futures)}"
+        )
+        for fut in futures:
+            assert fut.done(), (
+                "client.call() on a closed client must resolve the "
+                "future synchronously so publish() never raises"
+            )
+            with pytest.raises(ConnectionError):
+                fut.result(timeout=1.0)
+    finally:
+        pub.shutdown()
+        sub_a.shutdown()
+        sub_b.shutdown()
+        for p in three_free_ports:
+            wait_port_free(p)
+
+
 def test_context_manager_shuts_down_on_exit(
     three_free_ports: list[int],
 ) -> None:


### PR DESCRIPTION
## Summary

- `TinyNode.publish` wrapped `client.call` in `except (ConnectionError, OSError, RuntimeError)` — but `TinyClient.call` never raises synchronously. Every failure already lands on the returned future. The handler was dead code and the docstring misled about what `publish` actually does.
- Simplify the loop, tighten the docstring to describe the actual async-only failure contract.
- Surface the fast-fail case: `call()` resolves the future synchronously when the client has been shut down. `publish` now logs those immediate failures on the publish side — operators see the problem without having to await every future — but still returns the future so callers get a consistent shape.

Closes #12

## PR train

Stacked on **#24** (`fix/raise-on-missing-callback`). When #24 merges, GitHub will retarget this PR to `main` automatically.

## Test plan

- [x] New test `test_publish_returns_failed_future_for_closed_client`: close every outbound client on the publisher, call `publish`, assert the returned futures are immediately `done()` and raise `ConnectionError` — documenting the sync-resolve-on-failure invariant.
- [x] Existing suite: `uv run pytest` → 47 passed, 89 skipped.
- [x] Lint / type: `uv run pre-commit run --all-files` and `--hook-stage push --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
