### PR TITLE
fix(server): prune per-connection bookkeeping; stop leaking reader threads

### DIFF
--- a/src/tinyros/transport.py
+++ b/src/tinyros/transport.py
@@ -364,9 +364,14 @@ class TinyServer:
         )
         self._server_sock: socket.socket | None = None
         self._accept_thread: threading.Thread | None = None
-        self._reader_threads: list[threading.Thread] = []
-        self._conns: list[socket.socket] = []
-        self._conn_send_locks: dict[int, threading.Lock] = {}
+        # Per-connection bookkeeping is keyed by the connection socket
+        # itself so drop_conn can prune each map and bounded memory
+        # holds across many connect/disconnect cycles. id(conn) would
+        # work while the object is live but is fragile if a future
+        # refactor lets any map outlive the socket.
+        self._reader_threads: dict[socket.socket, threading.Thread] = {}
+        self._conns: set[socket.socket] = set()
+        self._conn_send_locks: dict[socket.socket, threading.Lock] = {}
         self._conns_lock = threading.Lock()
         self._running = threading.Event()
         self._started = False
@@ -429,8 +434,15 @@ class TinyServer:
                 pass
             self._server_sock = None
 
+        # Join the accept loop before snapshotting so a race-accepted
+        # connection can't be registered after the snapshot and leak
+        # its reader thread out of close().
+        if self._accept_thread is not None:
+            self._accept_thread.join(timeout=timeout)
+
         with self._conns_lock:
             conns = list(self._conns)
+            readers = list(self._reader_threads.values())
         for conn in conns:
             try:
                 conn.shutdown(socket.SHUT_RDWR)
@@ -441,9 +453,7 @@ class TinyServer:
             except OSError:
                 pass
 
-        if self._accept_thread is not None:
-            self._accept_thread.join(timeout=timeout)
-        for t in self._reader_threads:
+        for t in readers:
             t.join(timeout=timeout)
 
         self._pool.shutdown(wait=True, cancel_futures=True)
@@ -462,19 +472,40 @@ class TinyServer:
                 continue
             except OSError:
                 return
+            # close() may have cleared _running while accept() was
+            # blocking; drop the new conn instead of leaking a reader.
+            if not self._running.is_set():
+                try:
+                    conn.close()
+                except OSError:
+                    pass
+                return
             conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             conn.settimeout(_READ_POLL_S)
-            with self._conns_lock:
-                self._conns.append(conn)
-                self._conn_send_locks[id(conn)] = threading.Lock()
             reader = threading.Thread(
                 target=self._reader_loop,
                 args=(conn,),
                 daemon=True,
                 name=f"tinyros-reader-{self.name}-{conn.fileno()}",
             )
-            reader.start()
-            self._reader_threads.append(reader)
+            with self._conns_lock:
+                self._conns.add(conn)
+                self._conn_send_locks[conn] = threading.Lock()
+                self._reader_threads[conn] = reader
+                try:
+                    reader.start()
+                except RuntimeError:
+                    # Starting the thread failed (e.g., interpreter
+                    # shutdown). Unregister so close()'s reader snapshot
+                    # doesn't try to join a thread that never started.
+                    self._conns.discard(conn)
+                    self._conn_send_locks.pop(conn, None)
+                    self._reader_threads.pop(conn, None)
+                    try:
+                        conn.close()
+                    except OSError:
+                        pass
+                    return
 
     def _reader_loop(self, conn: socket.socket) -> None:
         """Read framed messages from ``conn`` and dispatch callbacks.
@@ -567,7 +598,7 @@ class TinyServer:
                 )
             )
         frame = _frame(_MSG_REPLY, body)
-        lock = self._conn_send_locks.get(id(call.conn))
+        lock = self._conn_send_locks.get(call.conn)
         if lock is None:
             return
         with lock:
@@ -591,11 +622,9 @@ class TinyServer:
         except OSError:
             pass
         with self._conns_lock:
-            try:
-                self._conns.remove(conn)
-            except ValueError:
-                pass
-            self._conn_send_locks.pop(id(conn), None)
+            self._conns.discard(conn)
+            self._conn_send_locks.pop(conn, None)
+            self._reader_threads.pop(conn, None)
 
 
 # --- Client ---------------------------------------------------------------

--- a/tests/test_transport_rpc.py
+++ b/tests/test_transport_rpc.py
@@ -266,6 +266,100 @@ def test_shutdown_releases_blocked_reader(free_port: int) -> None:
         wait_port_free(free_port)
 
 
+def test_server_conn_bookkeeping_shrinks_after_disconnect(
+    free_port: int,
+) -> None:
+    """Each connection's bookkeeping is removed when the client leaves.
+
+    Previously ``_reader_threads`` was an append-only list and the
+    other maps were keyed by ``id(conn)``; a server that saw many
+    connect/disconnect cycles kept a ``Thread`` object per historical
+    connection forever. Now every structure shrinks back to empty.
+    """
+    server = TinyServer(name="t-leak", host="127.0.0.1", port=free_port)
+    server.bind("noop", lambda _x: None)
+    server.start(block=False)
+    cycles = 30
+    try:
+        for i in range(cycles):
+            client = TinyClient(host="127.0.0.1", port=free_port, name=f"c-{i}")
+            client.call("noop", i).result(timeout=2.0)
+            client.close(timeout=1.0)
+        # _drop_conn runs on the reader thread once the client closes
+        # its side -- give it a moment to prune.
+        deadline = time.monotonic() + 2.0
+        while (
+            len(server._reader_threads) > 0  # noqa: SLF001
+            or len(server._conns) > 0  # noqa: SLF001
+            or len(server._conn_send_locks) > 0  # noqa: SLF001
+        ) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert len(server._reader_threads) == 0, (  # noqa: SLF001
+            f"reader thread map should be empty after {cycles} "
+            f"disconnects; got {len(server._reader_threads)}"  # noqa: SLF001
+        )
+        assert (
+            len(server._conns) == 0
+        ), (  # noqa: SLF001
+            f"conn set should be empty; got {len(server._conns)}"  # noqa: SLF001
+        )
+        assert len(server._conn_send_locks) == 0, (  # noqa: SLF001
+            f"send-lock map should be empty; "
+            f"got {len(server._conn_send_locks)}"  # noqa: SLF001
+        )
+    finally:
+        server.close(timeout=1.0)
+        wait_port_free(free_port)
+
+
+def test_close_joins_readers_accepted_concurrently(free_port: int) -> None:
+    """close() must not leak a reader thread racing with a late accept.
+
+    The earlier version snapshotted ``_reader_threads`` before joining
+    ``_accept_thread``. If a client connected between the snapshot and
+    the accept loop actually exiting, its reader would be registered
+    after the snapshot and never joined -- leaking the thread and the
+    connection bookkeeping. Drive many concurrent connects during
+    ``close()`` and assert everything is drained.
+    """
+    server = TinyServer(name="t-race-close", host="127.0.0.1", port=free_port)
+    server.bind("noop", lambda _x: None)
+    server.start(block=False)
+    stop = threading.Event()
+
+    def hammer() -> None:
+        while not stop.is_set():
+            try:
+                c = TinyClient(
+                    host="127.0.0.1", port=free_port, name="hammer", connect_timeout=0.5
+                )
+            except OSError:
+                return
+            try:
+                c.close(timeout=0.5)
+            except OSError:
+                pass
+
+    hammers = [threading.Thread(target=hammer, daemon=True) for _ in range(4)]
+    for t in hammers:
+        t.start()
+    try:
+        time.sleep(0.1)
+    finally:
+        stop.set()
+        server.close(timeout=2.0)
+        for t in hammers:
+            t.join(timeout=2.0)
+        wait_port_free(free_port)
+    assert len(server._reader_threads) == 0, (  # noqa: SLF001
+        "close() should have joined and removed every reader thread, "
+        f"got {len(server._reader_threads)}"  # noqa: SLF001
+    )
+    assert (
+        len(server._conns) == 0
+    ), f"close() should have drained _conns, got {len(server._conns)}"  # noqa: SLF001
+
+
 def test_oversized_frame_header_drops_connection(free_port: int) -> None:
     """A peer claiming an absurd frame length is disconnected, not buffered.
 


### PR DESCRIPTION
## Summary

Two related server-side bookkeeping fixes:

1. **`_reader_threads` was append-only.** Every accepted connection appended a `Thread` to the list; `_drop_conn` never removed it. A server that saw many connect/disconnect cycles accumulated one `Thread` object per historical connection forever. Switch to `dict[socket.socket, Thread]` and pop on `_drop_conn`.
2. **`_conn_send_locks` was keyed by `id(conn)`.** `id()` is only unique while the object is alive — any future refactor that kept an entry alive past the socket's lifetime would collide with a reused id. Key directly on `conn`.

While there, convert `_conns` from `list` to `set` — O(1) add/discard and matches the lookup semantics `_drop_conn` already used (it was doing `list.remove` where `set.discard` is clearer).

Closes #8

## PR train

Stacked on **#23** (`fix/unpicklable-exception-hang`). Base retargets to `main` when #22 → #23 land.

## Test plan

- [x] New test `test_server_conn_bookkeeping_shrinks_after_disconnect`: cycle 30 clients against one server, await `_drop_conn` to prune, assert `_reader_threads`, `_conns`, `_conn_send_locks` all return to size 0. On HEAD the reader-thread list would stay at 30.
- [x] Existing suite: `uv run pytest` → 47 passed, 89 skipped.
- [x] Lint / type: `uv run pre-commit run --all-files` and `--hook-stage push --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
