### PR TITLE
docs(transport): document shm fast-path top-level-only scope

### DIFF
--- a/docs/guides/architecture/transport.md
+++ b/docs/guides/architecture/transport.md
@@ -47,6 +47,29 @@ zero-copy side-channel:
 The client tracks outstanding block names so segments never leak if the
 send queue is dropped during shutdown.
 
+### Scope: top-level ndarrays only
+
+The shm path activates **only when the call argument is itself a bare
+ndarray** — `client.call("topic", arr)`. Any structure around the array
+keeps the payload inline:
+
+- `client.call("topic", (header, arr))` — tuple wrapper → inline
+- `client.call("topic", {"img": arr})` — dict wrapper → inline
+- `client.call("topic", MyMessage(image=arr))` — custom class → inline
+
+Inline payloads use pickle protocol 5 with out-of-band buffers, so
+ndarray bytes never land in the main pickle blob. They are still
+copied into the wire payload and sent through the socket, which stays
+fast for small messages but is meaningfully slower than the shm
+side-channel for large arrays.
+
+If you want the fast path for a typed message, either pass the array
+as the top-level argument and send the metadata separately, or shape
+your callback signature so the hot field is the ndarray and the
+auxiliary state lives on the subscriber's own attributes. Walking the
+argument graph to hoist nested ndarrays into shm is a plausible
+future change but is not implemented today.
+
 ## Endpoint abstraction
 
 The transport uses TCP stream sockets (`AF_INET` / `SOCK_STREAM`). Each

--- a/docs/guides/architecture/transport.md
+++ b/docs/guides/architecture/transport.md
@@ -50,12 +50,16 @@ send queue is dropped during shutdown.
 ### Scope: top-level ndarrays only
 
 The shm path activates **only when the call argument is itself a bare
-ndarray** — `client.call("topic", arr)`. Any structure around the array
-keeps the payload inline:
+ndarray** — `client.call("on_image", arr)`. Any structure around the
+array keeps the payload inline:
 
-- `client.call("topic", (header, arr))` — tuple wrapper → inline
-- `client.call("topic", {"img": arr})` — dict wrapper → inline
-- `client.call("topic", MyMessage(image=arr))` — custom class → inline
+- `client.call("on_image", (header, arr))` — tuple wrapper → inline
+- `client.call("on_image", {"img": arr})` — dict wrapper → inline
+- `client.call("on_image", MyMessage(image=arr))` — custom class → inline
+
+(`TinyClient.call` takes a remote callback name as its first argument,
+not a topic. `TinyNode.publish("topic", msg)` resolves the topic to one
+or more `client.call(cb_name, msg)` invocations under the hood.)
 
 Inline payloads use pickle protocol 5 with out-of-band buffers, so
 ndarray bytes never land in the main pickle blob. They are still

--- a/docs/guides/architecture/transport.md
+++ b/docs/guides/architecture/transport.md
@@ -70,6 +70,23 @@ auxiliary state lives on the subscriber's own attributes. Walking the
 argument graph to hoist nested ndarrays into shm is a plausible
 future change but is not implemented today.
 
+### Views and non-contiguous arrays
+
+Numpy *views* (slices, transposes, reshapes that share memory with a
+base array) are themselves ndarrays, so they enter the fast path under
+the same rule as a freshly allocated array. The threshold is evaluated
+against `view.nbytes` -- the *logical* extent (`prod(shape) * itemsize`),
+not the underlying base buffer's size. A small slice of a multi-GiB
+array therefore stays inline; a large strided view of the same array
+travels via shm on its own merits.
+
+Whatever the source's contiguity, the encoder writes a fresh
+C-contiguous copy of the view's logical extent into the shm block (via
+`target[...] = view`), and the receiver materializes a fresh contiguous
+ndarray of the same shape, dtype, and values. View semantics -- sharing
+memory with the base on the sender -- do not, and cannot, survive
+cross-process delivery; the receiver always owns its own buffer.
+
 ## Endpoint abstraction
 
 The transport uses TCP stream sockets (`AF_INET` / `SOCK_STREAM`). Each

--- a/src/tinyros/transport.py
+++ b/src/tinyros/transport.py
@@ -9,7 +9,7 @@ Two public classes:
 
 Wire protocol (framed with a 1-byte kind + 4-byte length header):
 
-- ``CALL``: inline pickle-protocol-5 payload with out-of-band buffers.
+- ``CALL``: inline pickle protocol 5 payload with out-of-band buffers.
 - ``CALL_LARGE``: metadata frame whose single ndarray payload travels
   through :mod:`multiprocessing.shared_memory`, bypassing the socket.
 - ``REPLY``: pickled ``(req_id, ok, result_or_exception)``.
@@ -21,7 +21,7 @@ ndarray whose ``nbytes`` is at least the configured threshold (default
 ``shm_threshold`` constructor kwarg; ``0`` disables the fast path).
 Only **top-level** ndarrays trigger the fast path -- arrays nested
 inside a tuple, dict, or custom message class travel inline via
-pickle-5 out-of-band buffers. Pass a bare ndarray as the call argument
+pickle protocol 5 out-of-band buffers. Pass a bare ndarray as the call argument
 when you want cross-process delivery to skip the socket copy.
 
 Inline frames (CALL without the shm path and every REPLY) are capped at
@@ -806,7 +806,7 @@ class TinyClient:
         When ``arg`` is a bare ndarray whose ``nbytes`` meets the shm
         threshold, the array travels through shared memory. Nested
         ndarrays (inside a tuple, dict, or custom message class) always
-        travel inline via pickle-5 out-of-band buffers. For
+        travel inline via pickle protocol 5 out-of-band buffers. For
         cross-process delivery, that path still copies the bytes
         through the socket. Pass the array at the top level when the
         shm fast path matters.

--- a/src/tinyros/transport.py
+++ b/src/tinyros/transport.py
@@ -19,6 +19,10 @@ The shared-memory side-channel activates when the call argument is an
 ndarray whose ``nbytes`` is at least the configured threshold (default
 64 KiB, set via the ``TINYROS_SHM_THRESHOLD`` env var or the
 ``shm_threshold`` constructor kwarg; ``0`` disables the fast path).
+Only **top-level** ndarrays trigger the fast path -- arrays nested
+inside a tuple, dict, or custom message class travel inline via
+pickle-5 out-of-band buffers. Pass a bare ndarray as the call argument
+when you want cross-process delivery to skip the socket copy.
 
 Inline frames (CALL without the shm path and every REPLY) are capped at
 ``TINYROS_MAX_FRAME_BYTES`` bytes (default 256 MiB) so a misbehaving
@@ -798,6 +802,14 @@ class TinyClient:
 
     def call(self, method: str, arg: Any) -> concurrent.futures.Future:
         """Send an RPC call and return a future for the reply.
+
+        When ``arg`` is a bare ndarray whose ``nbytes`` meets the shm
+        threshold, the array travels through shared memory. Nested
+        ndarrays (inside a tuple, dict, or custom message class) always
+        travel inline via pickle-5 out-of-band buffers. For
+        cross-process delivery, that path still copies the bytes
+        through the socket. Pass the array at the top level when the
+        shm fast path matters.
 
         Args:
             method: Callback name registered on the server.

--- a/tests/test_transport_rpc.py
+++ b/tests/test_transport_rpc.py
@@ -98,6 +98,48 @@ def test_large_ndarray_uses_shm_fast_path(
     ), "server should observe the full ndarray through shm"
 
 
+def test_noncontiguous_view_roundtrips_via_shm(
+    server_client_pair: ServerClientFactory,
+) -> None:
+    """A non-contiguous ndarray *view* takes the shm path and arrives intact.
+
+    A view is itself an ``ndarray`` (``isinstance`` check on the encoder
+    is true) and ``view.nbytes`` is the *logical* extent (shape *
+    itemsize), not the underlying base buffer's size. So a strided slice
+    above the threshold qualifies for the fast path on its own merits;
+    a small slice of a giant base stays inline. The encoder copies via
+    ``target[...] = view``, which is element-wise and faithfully
+    materializes a non-contiguous source into the contiguous shm buffer.
+    The receiver gets a fresh contiguous copy of the same shape, dtype,
+    and values; view semantics (sharing memory with the base) do not --
+    and cannot -- survive cross-process delivery.
+    """
+
+    def echo_arr(arr: np.ndarray) -> np.ndarray:
+        return arr
+
+    _server, client, _ = server_client_pair(echo_arr=echo_arr)
+    # Base is 4 MiB; the strided view is 1 MiB logical, non-contiguous.
+    # Both the base and the view exceed the default 64 KiB threshold,
+    # so the view alone is enough to trigger the shm path.
+    base = np.arange(1024 * 1024, dtype=np.float32).reshape(1024, 1024)
+    view = base[::2, ::2]
+    assert not view.flags["C_CONTIGUOUS"], "view must be non-contiguous for this test"
+    assert view.nbytes < base.nbytes, "view.nbytes should reflect the logical extent"
+
+    fut = client.call("echo_arr", view)
+    received = fut.result(timeout=3.0)
+
+    assert isinstance(
+        received, np.ndarray
+    ), f"expected ndarray, got {type(received).__name__}"
+    assert received.shape == view.shape, f"shape: {received.shape!r} vs {view.shape!r}"
+    assert received.dtype == view.dtype, f"dtype: {received.dtype!r} vs {view.dtype!r}"
+    assert np.array_equal(
+        received, view
+    ), "non-contiguous view should arrive with bit-identical values"
+
+
 def test_remote_exception_propagates(
     server_client_pair: ServerClientFactory,
 ) -> None:


### PR DESCRIPTION
## Summary

- **Document the shm fast-path scope explicitly.** The path only triggers when the call argument is itself a bare ndarray. Arrays nested inside a tuple, dict, or custom message class travel inline via pickle-5 OOB buffers — fast intra-process, but copies bytes through the socket for cross-process delivery.
- Add a "Scope: top-level ndarrays only" subsection to `docs/guides/architecture/transport.md` with concrete examples and a note on the recommended topic design.
- Tighten `transport.py`'s module docstring and `TinyClient.call` docstring so the limitation is visible from `help()` without reading the architecture guide.

## Scope (what this PR does *not* do)

The issue listed two options: (1) walk the argument graph at encode time and hoist every qualifying ndarray into its own shm block, or (2) document sharply. This PR takes (2) — a contained change that closes the ambiguity. The behavioral fix (1) is a meaningful wire-format change (`CALL_LARGE_MULTI`) and can be re-filed as its own issue if the inline path actually becomes a bottleneck for someone's topic design.

Closes #10

## PR train

Stacked on **#28** (`fix/server-bind-after-start`). Base retargets to `main` when #22 → #23 → #26 → #28 land.

## Test plan

- [x] Existing suite: `uv run pytest` → 48 passed, 89 skipped. No code behavior changed.
- [x] Lint / type: `uv run pre-commit run --all-files` and `--hook-stage push --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
