### PR TITLE
refactor(node): deeply freeze network config, validate cross-refs, unregister atexit

### DIFF
--- a/src/tinyros/node.py
+++ b/src/tinyros/node.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 import atexit
 import concurrent.futures
 import ipaddress
+from collections.abc import Mapping
 from dataclasses import dataclass
-from types import TracebackType
+from types import MappingProxyType, TracebackType
 from typing import Any
 
 from ._logging import get_logger
@@ -90,14 +91,33 @@ class TinyNodeDescription:
 class TinyNetworkConfig:
     """Immutable network topology.
 
+    ``nodes`` and the inner ``connections`` mappings are exposed as
+    read-only ``MappingProxyType`` views, and subscription lists are
+    stored as tuples. Mutation attempts raise ``TypeError`` on the
+    mapping views and ``AttributeError`` on the tuple (e.g., calling
+    ``.append`` on a subscription list), so the frozen-dataclass
+    promise extends to the nested structures, not just attribute
+    rebinding.
+
     Args:
         nodes: Mapping of node name to its :class:`TinyNodeDescription`.
         connections: Mapping of ``publisher_name -> topic_name ->
             subscriptions``.
     """
 
-    nodes: dict[str, TinyNodeDescription]
-    connections: dict[str, dict[str, list[TinySubscription]]]
+    nodes: Mapping[str, TinyNodeDescription]
+    connections: Mapping[str, Mapping[str, tuple[TinySubscription, ...]]]
+
+    def __post_init__(self) -> None:
+        """Freeze nested mappings and subscription lists."""
+        object.__setattr__(self, "nodes", MappingProxyType(dict(self.nodes)))
+        frozen = {
+            publisher: MappingProxyType(
+                {topic: tuple(subs) for topic, subs in topics.items()}
+            )
+            for publisher, topics in self.connections.items()
+        }
+        object.__setattr__(self, "connections", MappingProxyType(frozen))
 
     def get_node_by_name(self, name: str) -> TinyNodeDescription:
         """Look up a node by name.
@@ -117,16 +137,16 @@ class TinyNetworkConfig:
 
     def get_publishers_for_node(
         self, node_name: str
-    ) -> dict[str, list[TinySubscription]]:
+    ) -> Mapping[str, tuple[TinySubscription, ...]]:
         """Get topics that ``node_name`` publishes and their subscribers.
 
         Args:
             node_name: Node whose outbound topics to return.
 
         Returns:
-            Mapping of topic name to the list of subscriptions.
+            Mapping of topic name to the tuple of subscriptions.
         """
-        return self.connections.get(node_name, {})
+        return self.connections.get(node_name, MappingProxyType({}))
 
     def get_subscribers_for_node(self, node_name: str) -> dict[str, str]:
         """Get topics that ``node_name`` subscribes to, keyed by topic.
@@ -146,14 +166,23 @@ class TinyNetworkConfig:
         return subscribers
 
     @classmethod
-    def load_from_config(cls, config: dict) -> TinyNetworkConfig:
+    def load_from_config(cls, config: dict[str, Any]) -> TinyNetworkConfig:
         """Parse a dictionary into a :class:`TinyNetworkConfig`.
+
+        Validates that every publisher and every subscription actor is
+        declared in ``nodes`` before returning, so a typo in the YAML
+        raises a clear error here instead of blowing up later during
+        :class:`TinyNode` setup.
 
         Args:
             config: Raw config dictionary (typically from YAML).
 
         Returns:
             The parsed immutable network config.
+
+        Raises:
+            ValueError: If a publisher or subscription actor references
+                a node name that is not present in ``nodes``.
         """
         nodes = {
             node_name: TinyNodeDescription(
@@ -161,15 +190,28 @@ class TinyNetworkConfig:
             )
             for node_name, node_data in config["nodes"].items()
         }
-        connections: dict[str, dict[str, list[TinySubscription]]] = {}
+        connections: dict[str, dict[str, tuple[TinySubscription, ...]]] = {}
         for publisher_name, topics in config["connections"].items():
+            if publisher_name not in nodes:
+                raise ValueError(
+                    f"network config: publisher {publisher_name!r} has "
+                    f"connections but is not declared in 'nodes'"
+                )
             connections[publisher_name] = {
-                topic_name: [
+                topic_name: tuple(
                     TinySubscription(actor=sub["actor"], cb_name=sub["cb_name"])
                     for sub in subscribers
-                ]
+                )
                 for topic_name, subscribers in topics.items()
             }
+            for topic_name, subs in connections[publisher_name].items():
+                for sub in subs:
+                    if sub.actor not in nodes:
+                        raise ValueError(
+                            f"network config: subscription in "
+                            f"{publisher_name!r}/{topic_name!r} references "
+                            f"actor {sub.actor!r} that is not in 'nodes'"
+                        )
         return cls(nodes=nodes, connections=connections)
 
 
@@ -350,7 +392,13 @@ class TinyNode:
         return futures
 
     def shutdown(self) -> None:
-        """Shut the server and every outbound client down."""
+        """Shut the server and every outbound client down.
+
+        Unregisters the atexit hook up front so long-running processes
+        that create and destroy nodes dynamically don't accumulate
+        stale handlers in the atexit table.
+        """
+        atexit.unregister(self.shutdown)
         _logger.info(f"{self.name}: shutting down")
         try:
             self.server.close()

--- a/tests/benchmark/tinyros/test_speed_interprocess.py
+++ b/tests/benchmark/tinyros/test_speed_interprocess.py
@@ -116,7 +116,7 @@ def _make_network(pub_port: int, sub_port: int) -> TinyNetworkConfig:
         },
         connections={
             "pub": {
-                "topic": [TinySubscription(actor="sub", cb_name="on_msg")],
+                "topic": (TinySubscription(actor="sub", cb_name="on_msg"),),
             },
         },
     )

--- a/tests/benchmark/tinyros/test_speed_tinyros.py
+++ b/tests/benchmark/tinyros/test_speed_tinyros.py
@@ -186,7 +186,7 @@ def test_latency_cpu_gpu_payloads(
             "sub": TinyNodeDescription(port=sub_port, host="localhost"),
         },
         connections={
-            "pub": {"topic": [TinySubscription(actor="sub", cb_name="on_msg")]}
+            "pub": {"topic": (TinySubscription(actor="sub", cb_name="on_msg"),)}
         },
     )
 

--- a/tests/test_network_config.py
+++ b/tests/test_network_config.py
@@ -47,12 +47,57 @@ def test_load_parses_nodes_into_descriptions() -> None:
 
 
 def test_load_parses_connections_into_subscriptions() -> None:
-    """load_from_config produces TinySubscription lists, not raw dicts."""
+    """load_from_config produces TinySubscription tuples, not raw dicts."""
     cfg = TinyNetworkConfig.load_from_config(_RAW_CONFIG)
-    assert cfg.connections["B"]["t_b"] == [
+    assert cfg.connections["B"]["t_b"] == (
         TinySubscription(actor="A", cb_name="on_b_for_a"),
         TinySubscription(actor="C", cb_name="on_b_for_c"),
-    ], "connections should preserve declaration order and subscription type"
+    ), "connections should preserve declaration order and subscription type"
+
+
+def test_config_is_deeply_immutable() -> None:
+    """Nested mappings and subscription lists reject in-place mutation.
+
+    The dataclass is ``frozen=True``, which used to only prevent
+    rebinding the attribute -- the nested dict/list values could still
+    be mutated silently. With the MappingProxy/tuple wrapping this
+    avenue is gone.
+    """
+    cfg = TinyNetworkConfig.load_from_config(_RAW_CONFIG)
+    with pytest.raises(TypeError):
+        cfg.nodes["X"] = TinyNodeDescription(port=9, host="localhost")  # type: ignore[index]
+    with pytest.raises(TypeError):
+        cfg.connections["A"]["t_a"] = ()  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        # Subscription tuples have no ``append``; this is the common
+        # accidental-mutation case that used to succeed silently.
+        cfg.connections["A"]["t_a"].append(  # type: ignore[attr-defined]
+            TinySubscription(actor="D", cb_name="on_x")
+        )
+
+
+def test_load_rejects_unknown_subscription_actor() -> None:
+    """A subscription naming a node not in ``nodes`` fails at load."""
+    bad = {
+        "nodes": {"A": {"port": 1, "host": "localhost"}},
+        "connections": {
+            "A": {"t": [{"actor": "GHOST", "cb_name": "on_x"}]},
+        },
+    }
+    with pytest.raises(ValueError, match="GHOST"):
+        TinyNetworkConfig.load_from_config(bad)
+
+
+def test_load_rejects_unknown_publisher() -> None:
+    """A publisher not in ``nodes`` fails at load."""
+    bad = {
+        "nodes": {"A": {"port": 1, "host": "localhost"}},
+        "connections": {
+            "GHOST_PUB": {"t": [{"actor": "A", "cb_name": "on_x"}]},
+        },
+    }
+    with pytest.raises(ValueError, match="GHOST_PUB"):
+        TinyNetworkConfig.load_from_config(bad)
 
 
 def test_get_node_by_name_returns_description() -> None:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -37,10 +37,10 @@ def _make_config(ports: dict[str, int]) -> TinyNetworkConfig:
         },
         connections={
             "pub": {
-                "topic": [
+                "topic": (
                     TinySubscription(actor="sub_a", cb_name="on_topic"),
                     TinySubscription(actor="sub_b", cb_name="on_topic"),
-                ],
+                ),
             },
         },
     )


### PR DESCRIPTION
## Summary

Three cleanups packaged together since they all touch `node.py`:

1. **`TinyNetworkConfig` is now deeply frozen.** `@dataclass(frozen=True)` previously only prevented rebinding the attribute — the nested dicts and lists were still mutable. `__post_init__` now wraps `nodes` and `connections` with `MappingProxyType` and converts each subscription list to a tuple. `cfg.nodes["X"] = …` raises `TypeError`; `cfg.connections[pub][topic].append(…)` raises `AttributeError`. The frozen promise extends to the whole structure.
2. **Config cross-reference validation at parse time.** `load_from_config` previously accepted configs where a publisher or subscription actor referenced a node not declared under `nodes` — the error surfaced only later, during `TinyNode._setup_publishing`, as an obscure `ValueError` from `get_node_by_name`. Validate both paths at load with a clear message naming the offending key.
3. **`TinyNode.shutdown` unregisters its atexit hook.** Long-running processes that create/destroy nodes dynamically no longer accumulate stale handlers in the atexit table.

**Type follow-through:** `connections` annotated as `Mapping[str, Mapping[str, tuple[TinySubscription, ...]]]`. Direct-construction call sites in tests and the benchmark fixture updated to pass tuples.

## Breaking change

- `cfg.connections[...][...]` is now a `tuple`, not a `list`. Callers doing `== [sub, sub]` must switch to `== (sub, sub)`; `.append` etc. no longer work.
- Configs with unknown publishers or subscription actors fail at `load_from_config` instead of later at runtime.

Closes #18

## PR train

Stacked on **#27** (`fix/default-bind-host-loopback`). Base retargets to `main` when #24 → #25 → #27 land.

## Test plan

- [x] New `test_config_is_deeply_immutable`: mutation on `nodes`, on a topic's subscription tuple, and on the inner topic map each raises the expected error.
- [x] New `test_load_rejects_unknown_subscription_actor`: config whose subscription names a non-existent actor fails with `ValueError`.
- [x] New `test_load_rejects_unknown_publisher`: config whose publisher key is not in `nodes` fails with `ValueError`.
- [x] Existing subscription-shape test updated to expect tuples.
- [x] Full suite: `uv run pytest` → 59 passed (was 56), 89 skipped.
- [x] Lint / type: `uv run pre-commit run --all-files` and `--hook-stage push --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
