### PR TITLE
polish(transport, main): misc cleanups

### DIFF
--- a/main.py
+++ b/main.py
@@ -227,11 +227,23 @@ def main() -> None:
         except KeyboardInterrupt:
             _logger.info("shutting down all processes")
     finally:
+        # Ask nicely first: SIGTERM gives each child a chance to exit
+        # cleanly (atexit runs only if the child installs a handler,
+        # but Ctrl+C at the terminal also propagates SIGINT to the
+        # whole process group -- most nodes exit gracefully by that
+        # path alone).
         for p in procs:
             if p.is_alive():
                 p.terminate()
         for p in procs:
-            p.join(timeout=5.0)
+            p.join(timeout=3.0)
+        # Escalate for any children that ignored SIGTERM.
+        stragglers = [p for p in procs if p.is_alive()]
+        for p in stragglers:
+            _logger.warning(f"process {p.name} did not exit; killing")
+            p.kill()
+        for p in stragglers:
+            p.join(timeout=2.0)
         _logger.info("all processes stopped")
 
 

--- a/main.py
+++ b/main.py
@@ -244,7 +244,17 @@ def main() -> None:
             p.kill()
         for p in stragglers:
             p.join(timeout=2.0)
-        _logger.info("all processes stopped")
+        # A child stuck in an uninterruptible kernel call (D-state) can
+        # survive ``kill()``; reflect that in the log so the operator
+        # knows the parent is leaving non-daemon children behind.
+        survivors = [p for p in procs if p.is_alive()]
+        if survivors:
+            _logger.error(
+                f"failed to stop {len(survivors)} process(es): "
+                f"{[p.name for p in survivors]}"
+            )
+        else:
+            _logger.info("all processes stopped")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -227,17 +227,17 @@ def main() -> None:
         except KeyboardInterrupt:
             _logger.info("shutting down all processes")
     finally:
-        # Ask nicely first: SIGTERM gives each child a chance to exit
-        # cleanly (atexit runs only if the child installs a handler,
-        # but Ctrl+C at the terminal also propagates SIGINT to the
-        # whole process group -- most nodes exit gracefully by that
-        # path alone).
+        # Ask nicely first: ``terminate()`` requests a graceful exit
+        # (POSIX: SIGTERM; Windows: TerminateProcess). On a terminal
+        # Ctrl+C also propagates the interrupt signal to the whole
+        # process group on POSIX, so most nodes exit gracefully by
+        # that path alone before this loop runs.
         for p in procs:
             if p.is_alive():
                 p.terminate()
         for p in procs:
             p.join(timeout=3.0)
-        # Escalate for any children that ignored SIGTERM.
+        # Escalate for any children that ignored the graceful request.
         stragglers = [p for p in procs if p.is_alive()]
         for p in stragglers:
             _logger.warning(f"process {p.name} did not exit; killing")

--- a/src/tinyros/transport.py
+++ b/src/tinyros/transport.py
@@ -77,6 +77,7 @@ _RECONNECT_TIMEOUT_S = 2.0
 # ``_running`` and looping. Short enough that close() is responsive; long
 # enough that we don't burn CPU spinning on a saturated pool.
 _INFLIGHT_ACQUIRE_POLL_S = 0.2
+_LISTEN_BACKLOG = 64
 
 _SENTINEL = object()
 
@@ -485,7 +486,7 @@ class TinyServer:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.bind((self.host, self.port))
-        sock.listen(64)
+        sock.listen(_LISTEN_BACKLOG)
         sock.settimeout(_ACCEPT_POLL_S)
         self._server_sock = sock
 
@@ -502,8 +503,17 @@ class TinyServer:
     def close(self, timeout: float | None = 2.0) -> None:
         """Stop the server and release resources.
 
+        ``timeout`` gates the joins for the accept and reader threads.
+        The worker pool is drained with ``wait=True`` afterwards, so a
+        callback already running can extend ``close()`` past the
+        configured timeout; queued-but-not-yet-running callbacks are
+        cancelled via ``cancel_futures=True``. If you need a hard upper
+        bound, detach the server in a supervisor and reap the process
+        externally.
+
         Args:
-            timeout: Per-thread join timeout; ``None`` waits indefinitely.
+            timeout: Per-thread join timeout for the accept and reader
+                threads; ``None`` waits indefinitely.
         """
         with self._state_lock:
             if not self._running.is_set():
@@ -608,7 +618,9 @@ class TinyServer:
                         f"max {self._max_frame_bytes}); dropping connection"
                     )
                     return
-                body = _recvall(conn, length, self._running.is_set) if length else b""
+                # _recvall returns b"" for n=0 without touching the socket,
+                # so the length==0 path needs no special casing here.
+                body = _recvall(conn, length, self._running.is_set)
                 if body is None:
                     return
                 try:
@@ -1235,7 +1247,7 @@ class TinyClient:
                 )
                 self._shutdown_io()
                 return
-            body = _recvall(sock, length, self._running.is_set) if length else b""
+            body = _recvall(sock, length, self._running.is_set)
             if body is None:
                 if self._running.is_set():
                     self._fail_all_pending(
@@ -1243,6 +1255,10 @@ class TinyClient:
                     )
                 return
             if kind != _MSG_REPLY:
+                _logger.warning(
+                    f"{self.name}: unexpected non-reply frame kind "
+                    f"{kind} on the client socket; ignoring"
+                )
                 continue
             try:
                 req_id, ok, result = _unpack_oob(body)

--- a/tests/test_transport_framing.py
+++ b/tests/test_transport_framing.py
@@ -2,15 +2,17 @@
 
 Verifies that _pack_oob / _unpack_oob round-trip faithfully for scalars,
 strings, and numpy arrays whose buffers travel out-of-band via pickle
-protocol 5.
+protocol 5, and that _recvall short-circuits a zero-byte read.
 """
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 
-from tinyros.transport import _pack_oob, _unpack_oob
+from tinyros.transport import _pack_oob, _recvall, _unpack_oob
 
 
 @pytest.mark.parametrize(
@@ -58,6 +60,23 @@ def test_ndarray_roundtrip(shape: tuple[int, ...], dtype: type[np.generic]) -> N
     assert np.array_equal(
         decoded, arr
     ), "byte-identical payload expected after roundtrip"
+
+
+def test_recvall_zero_length_returns_empty_without_touching_socket() -> None:
+    """``_recvall`` with ``n == 0`` returns ``b""`` and never calls ``recv``.
+
+    The reader loops in ``transport.py`` rely on this short-circuit so a
+    framed message with an empty body decodes without a socket round-trip
+    and without consulting ``should_continue``.
+    """
+    sock = MagicMock()
+    should_continue = MagicMock(return_value=True)
+
+    result = _recvall(sock, 0, should_continue)
+
+    assert result == b"", f"expected b'' for n=0, got {result!r}"
+    sock.recv.assert_not_called()
+    should_continue.assert_not_called()
 
 
 def test_nested_ndarray_roundtrip() -> None:


### PR DESCRIPTION
## Summary

Small items packaged together so review and merge stay lightweight:

1. **`_recvall` on both reader loops no longer special-cases `length == 0`.** `_recvall(sock, 0, ...)` already returns `b""` without touching the socket — the `if length else b""` ternary was splitting the `None` check across two paths unnecessarily. Unconditional call + single `None` guard reads cleaner.
2. **Promote `listen(64)` to `_LISTEN_BACKLOG`** next to the other module constants.
3. **Log unknown reply frame kinds on the client** at `WARN` instead of silently skipping. Protocol drift / version skew now leaves a trail.
4. **`TinyServer.close()` docstring is honest about pool drain.** `timeout` only gates accept + reader thread joins; the worker pool is drained with `wait=True` afterwards so a slow callback can extend `close()` past the caller's budget. No code change — just stopped overpromising in the docstring.
5. **`main.py` escalates `SIGTERM` to `SIGKILL`** on any subprocess that doesn't exit within a 3 s grace window, with a warning log naming the straggler.

Items from the original polish bundle that are already landed via earlier PRs (`config: dict` → `dict[str, Any]` in #33, `publish` list-comp cleanup in #25) are intentionally not duplicated here.

Closes #19

## PR train

Stacked on **#32** (`fix/bounded-server-inflight`). Base retargets to `main` when the rest of the transport train lands.

## Test plan

- [x] Existing suite: `uv run pytest` → 50 passed, 89 skipped. No behavioral changes; items are refactor / doc / logging / escalation.
- [x] Lint / type: `uv run pre-commit run --all-files` and `--hook-stage push --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
