### PR TITLE
ci(commit-lint): allow `release` type

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -25,6 +25,7 @@
 #   - build: Changes affecting the build system or external dependencies
 #   - chore: Maintenance or tasks not affecting the code (e.g., version bumps)
 #   - ci: Changes to CI configuration files or scripts
+#   - release: Version bump / release commit
 # - "scope" is optional but helps provide context (e.g., module, feature, or component).
 # - "subject" should be concise and imperative (e.g., "add feature for user profile").
 # - Body provides additional detail, if needed (wrap at 72 characters per line).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,19 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
+        args:
+          - build
+          - chore
+          - ci
+          - docs
+          - feat
+          - fix
+          - perf
+          - refactor
+          - release
+          - revert
+          - style
+          - test
 
   - repo: local
     hooks:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'release',
+        'revert',
+        'style',
+        'test',
+      ],
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- Add the missing `commitlint.config.js` (the workflow already references it).
- Extend conventional-commits with a `release` type so version-bump commits like `release: 0.4.0` validate.
- Mirror the allowed types in the local `conventional-pre-commit` hook.
- Document `release` in `.gitmessage`.

## Test plan
- [x] Commit-lint job passes on this branch
- [x] Pre-commit hook accepts a sample `release: x.y.z` message locally

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)