### PR TITLE
ci(coverage): fail build below 80% line coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ addopts = [
         "--cov-report=term-missing",
         "--cov-report=html",
         "--cov-report=xml",
+        "--cov-fail-under=80",
 ]
 testpaths = ["tests"]
 # Exclude third-party comparison benchmarks that need their own runtimes


### PR DESCRIPTION
## Summary
- Add `--cov-fail-under=80` to `[tool.pytest.ini_options].addopts`.
- Current coverage is 85.58%; an 80% floor gives ~5pt buffer for refactors without making the gate cosmetic.

## Test plan
- [x] `uv run pytest` reports `Required test coverage of 80% reached. Total coverage: 85.58%`
- [ ] CI run on this branch is green

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)