### PR TITLE
ci: matrix-test python 3.10 / 3.11 / 3.12

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -9,16 +9,21 @@ jobs:
     code-style-check:
         runs-on: ubuntu-latest
 
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: ['3.10', '3.11', '3.12']
+
         steps:
             # Step 1: Check out the code
             - name: Check out code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
-            # Step 2: Set up Python
-            - name: Set up Python
-              uses: actions/setup-python@v4
+            # Step 2: Set up Python ${{ matrix.python-version }}
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v5
               with:
-                  python-version: '3.11'
+                  python-version: ${{ matrix.python-version }}
 
             # Step 3: Install dependencies
             - name: Install dependencies


### PR DESCRIPTION
## Summary
- Run the pre-commit style gate across Python 3.10, 3.11, and 3.12 — matching the floor declared in `pyproject.toml`.
- `fail-fast: false` so all three versions report their result independently.
- Bump `actions/checkout@v3` to v4 and `actions/setup-python@v4` to v5 (current majors).

Note: this workflow only runs `pre-commit run --all-files`, which executes the `pre-commit`-stage hooks — not pytest or basedpyright (those are gated on `pre-push` locally). Adding a CI job that actually runs the test suite is a separate concern; this PR is scope-limited to the matrix.

## Test plan
- [x] All three matrix legs go green on this branch
- [x] No regression in current 3.11 leg

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
