### PR TITLE
ci(security): add bandit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,14 @@ repos:
       - id: check-added-large-files
         args: ["--maxkb=1000"]
 
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.6
+    hooks:
+      - id: bandit
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]
+        files: ^src/
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.3.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,3 +142,10 @@ dev = [
     "build>=1.3.0",
     "twine>=6.2.0",
 ]
+
+# Bandit static security scan. Pickle deserialization (B301, B403) is
+# part of the documented transport design under a trusted-peer model,
+# so silencing it is intentional; everything else stays on.
+[tool.bandit]
+targets = ["src"]
+skips = ["B301", "B403"]


### PR DESCRIPTION
## Summary
- Add the [bandit](https://github.com/PyCQA/bandit) pre-commit hook scoped to `src/`.
- Configure `[tool.bandit]` in `pyproject.toml`: skip `B301` (pickle.loads) and `B403` (import pickle), since unpickling-over-socket is part of the documented transport design under the trusted-peer threat model. Rest of bandit's default ruleset stays on.

## Why
Cheap insurance against future regressions in the parts of the code that aren't pickle. Today's run is clean apart from the three skipped findings.

## Test plan
- [x] `uv run pre-commit run --all-files` includes the bandit hook and passes
- [x] CI run on this branch is green across all three Python matrix legs

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)
