### PR TITLE
refactor(transport): introduce typed exception hierarchy

### DIFF
--- a/src/tinyros/__init__.py
+++ b/src/tinyros/__init__.py
@@ -10,16 +10,25 @@ from .node import (
     TinyNodeDescription,
     TinySubscription,
 )
-from .transport import TinyClient, TinyServer
+from .transport import (
+    ConnectionLost,
+    SerializationError,
+    TinyClient,
+    TinyServer,
+    TransportError,
+)
 
 __version__ = "0.3.1"
 __all__ = [
+    "ConnectionLost",
+    "SerializationError",
     "TinyClient",
     "TinyNetworkConfig",
     "TinyNode",
     "TinyNodeDescription",
     "TinyServer",
     "TinySubscription",
+    "TransportError",
     "get_logger",
     "setup_console_logging",
 ]

--- a/src/tinyros/transport/__init__.py
+++ b/src/tinyros/transport/__init__.py
@@ -7,6 +7,7 @@ from ._client import TinyClient
 # Private symbols re-exported for tests and advanced users; they are
 # not part of the public API and may change without notice.
 from ._common import _MSG_CALL_LARGE  # noqa: F401
+from ._errors import ConnectionLost, SerializationError, TransportError
 from ._framing import (  # noqa: F401
     _frame,
     _pack_call_large,
@@ -16,4 +17,10 @@ from ._framing import (  # noqa: F401
 )
 from ._server import TinyServer
 
-__all__ = ["TinyClient", "TinyServer"]
+__all__ = [
+    "ConnectionLost",
+    "SerializationError",
+    "TinyClient",
+    "TinyServer",
+    "TransportError",
+]

--- a/src/tinyros/transport/_client.py
+++ b/src/tinyros/transport/_client.py
@@ -28,6 +28,7 @@ from ._common import (
     _default_shm_threshold,
     _logger,
 )
+from ._errors import ConnectionLost, SerializationError
 from ._framing import (
     _frame,
     _pack_call_large,
@@ -155,7 +156,7 @@ class TinyClient:
             The connected stream socket.
 
         Raises:
-            ConnectionError: If no connection could be established.
+            ConnectionLost: If no connection could be established.
         """
         deadline = time.monotonic() + timeout
         last_exc: OSError | None = None
@@ -172,7 +173,7 @@ class TinyClient:
             sock.settimeout(None)
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             return sock
-        raise ConnectionError(
+        raise ConnectionLost(
             f"tinyros client {self.name!r} could not connect to "
             f"{self.host}:{self.port} within {timeout:.1f}s: {last_exc}"
         )
@@ -211,7 +212,7 @@ class TinyClient:
         fut: concurrent.futures.Future = concurrent.futures.Future()
         if not self._running.is_set():
             fut.set_exception(
-                ConnectionError(f"tinyros client {self.name!r} is no longer running")
+                ConnectionLost(f"tinyros client {self.name!r} is no longer running")
             )
             return fut
         with self._req_id_lock:
@@ -220,7 +221,12 @@ class TinyClient:
         try:
             frame, shm_name = self._encode_call(req_id, method, arg)
         except Exception as exc:
-            fut.set_exception(exc)
+            fut.set_exception(
+                SerializationError(
+                    f"tinyros client {self.name!r}: failed to encode call to "
+                    f"{method!r}: {exc}"
+                )
+            )
             return fut
         # Insert into _pending and put on _send_queue under one lock so
         # the failure-handling block in _send_loop (which holds the same
@@ -229,9 +235,7 @@ class TinyClient:
         with self._pending_lock:
             if not self._running.is_set():
                 fut.set_exception(
-                    ConnectionError(
-                        f"tinyros client {self.name!r} is no longer running"
-                    )
+                    ConnectionLost(f"tinyros client {self.name!r} is no longer running")
                 )
                 if shm_name is not None:
                     with self._pending_shm_lock:
@@ -304,7 +308,7 @@ class TinyClient:
                 self._sock.sendall(frame)
             except OSError as exc:
                 _logger.warning(f"{self.name}: send failed ({exc})")
-                exc_for_pending = ConnectionError(
+                exc_for_pending = ConnectionLost(
                     f"tinyros client {self.name!r}: send failed ({exc})"
                 )
                 # Hold _pending_lock across the snapshot + clear + drain
@@ -398,7 +402,7 @@ class TinyClient:
             if header is None:
                 if self._running.is_set():
                     self._fail_all_pending(
-                        ConnectionError(
+                        ConnectionLost(
                             f"tinyros client {self.name!r}: server "
                             f"closed the connection"
                         )
@@ -411,7 +415,7 @@ class TinyClient:
                     f"max {self._max_frame_bytes}); tearing down"
                 )
                 self._stop_running(
-                    ConnectionError(
+                    ConnectionLost(
                         f"tinyros client {self.name!r}: oversized reply "
                         f"({length} bytes)"
                     )
@@ -422,7 +426,7 @@ class TinyClient:
             if body is None:
                 if self._running.is_set():
                     self._fail_all_pending(
-                        ConnectionError(f"tinyros client {self.name!r}: short read")
+                        ConnectionLost(f"tinyros client {self.name!r}: short read")
                     )
                 return
             if kind != _MSG_REPLY:
@@ -434,7 +438,10 @@ class TinyClient:
             try:
                 req_id, ok, result = _unpack_oob(body)
             except Exception as exc:
-                _logger.error(f"{self.name}: failed to decode reply: {exc}")
+                _logger.error(
+                    f"{self.name}: failed to decode reply: "
+                    f"{type(exc).__name__}: {exc}",
+                )
                 continue
             with self._pending_lock:
                 fut = self._pending.pop(int(req_id), None)
@@ -512,7 +519,7 @@ class TinyClient:
             self._recv_thread.join(timeout=1.0)
         try:
             new_sock = self._connect(self._reconnect_timeout)
-        except ConnectionError as exc:
+        except ConnectionLost as exc:
             _logger.warning(f"{self.name}: reconnect failed: {exc}")
             return False
         new_sock.settimeout(_READ_POLL_S)
@@ -568,7 +575,7 @@ class TinyClient:
         # Atomically block new call()s and drain anything already in
         # flight so a racing caller can't slip a future in after the
         # recv loop has been joined.
-        self._stop_running(ConnectionError(f"tinyros client {self.name!r} was closed"))
+        self._stop_running(ConnectionLost(f"tinyros client {self.name!r} was closed"))
 
         try:
             self._send_queue.put((_frame(_MSG_BYE, b""), None))

--- a/src/tinyros/transport/_errors.py
+++ b/src/tinyros/transport/_errors.py
@@ -1,0 +1,32 @@
+"""Public exception hierarchy for the transport layer.
+
+Callers can ``except`` on these to distinguish expected failure modes
+from bugs:
+
+- :class:`TransportError` -- base; catches everything raised
+  deliberately by this package.
+- :class:`ConnectionLost` -- the peer socket is gone (graceful close,
+  reset, reconnect deadline elapsed). Recovery is reconnect-and-retry.
+- :class:`SerializationError` -- the wire payload could not be packed
+  or unpacked (pickle, OOB metadata). Recovery is fix-the-payload --
+  retrying the same input will fail the same way.
+"""
+
+from __future__ import annotations
+
+
+class TransportError(Exception):
+    """Base class for all transport-layer exceptions raised by tinyros."""
+
+
+class ConnectionLost(TransportError, ConnectionError):
+    """The peer socket is gone or never became reachable.
+
+    Multi-inherits from :class:`ConnectionError` so that callers
+    written before the typed hierarchy (``except ConnectionError``)
+    keep catching it.
+    """
+
+
+class SerializationError(TransportError):
+    """A wire payload could not be packed or unpacked."""

--- a/tests/test_transport_errors.py
+++ b/tests/test_transport_errors.py
@@ -1,0 +1,90 @@
+"""Tests for the public transport exception hierarchy.
+
+Confirms the inheritance contract callers rely on -- in particular
+that pre-hierarchy code using ``except ConnectionError`` still
+catches the new typed :class:`ConnectionLost` -- and that the encode
+path raises a typed :class:`SerializationError`.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from tests.conftest import wait_port_free
+from tinyros import (
+    ConnectionLost,
+    SerializationError,
+    TransportError,
+)
+from tinyros.transport import TinyClient, TinyServer
+from tinyros.transport._errors import (
+    ConnectionLost as _ConnectionLost,
+)
+from tinyros.transport._errors import (
+    SerializationError as _SerializationError,
+)
+from tinyros.transport._errors import (
+    TransportError as _TransportError,
+)
+
+
+def test_top_level_reexports_match_module_classes() -> None:
+    """Public re-exports are the same objects as the module-level classes."""
+    assert TransportError is _TransportError
+    assert ConnectionLost is _ConnectionLost
+    assert SerializationError is _SerializationError
+
+
+def test_connection_lost_is_subclass_of_transport_error() -> None:
+    """Callers can catch any transport failure with ``except TransportError``."""
+    assert issubclass(ConnectionLost, TransportError)
+
+
+def test_serialization_error_is_subclass_of_transport_error() -> None:
+    """SerializationError participates in the unified hierarchy."""
+    assert issubclass(SerializationError, TransportError)
+
+
+def test_connection_lost_is_subclass_of_builtin_connection_error() -> None:
+    """Pre-hierarchy ``except ConnectionError`` callers keep working."""
+    assert issubclass(ConnectionLost, ConnectionError)
+
+
+def test_connection_lost_is_caught_by_except_connection_error() -> None:
+    """Demonstrate the backward-compat behavior end to end."""
+    with pytest.raises(ConnectionError):
+        raise ConnectionLost("peer gone")
+
+
+def test_serialization_error_is_not_a_connection_error() -> None:
+    """The two failure modes are disjoint at the catch-site."""
+    assert not issubclass(SerializationError, ConnectionError)
+
+
+def test_transport_error_is_an_exception() -> None:
+    """TransportError sits under Exception so bare ``except`` does not swallow it."""
+    assert issubclass(TransportError, Exception)
+    assert not issubclass(TransportError, BaseException) or issubclass(
+        TransportError, Exception
+    )
+
+
+def test_unpicklable_arg_surfaces_as_serialization_error(free_port: int) -> None:
+    """Sending a non-picklable arg fails the future with SerializationError."""
+    server = TinyServer(name="t-srv", host="127.0.0.1", port=free_port)
+    server.bind("noop", lambda x: x)
+    server.start(block=False)
+    client = TinyClient(host="127.0.0.1", port=free_port, name="t-cli")
+    try:
+        # ``threading.Lock`` instances are not picklable; the encode
+        # path must raise -- and the future must surface that as a
+        # typed SerializationError, not a bare ``TypeError``.
+        fut = client.call("noop", threading.Lock())
+        with pytest.raises(SerializationError):
+            fut.result(timeout=2.0)
+    finally:
+        client.close(timeout=1.0)
+        server.close(timeout=1.0)
+    wait_port_free(free_port)

--- a/tests/test_transport_errors.py
+++ b/tests/test_transport_errors.py
@@ -38,7 +38,7 @@ def test_top_level_reexports_match_module_classes() -> None:
 
 
 def test_connection_lost_is_subclass_of_transport_error() -> None:
-    """Callers can catch any transport failure with ``except TransportError``."""
+    """``except TransportError`` covers every drop the hierarchy emits."""
     assert issubclass(ConnectionLost, TransportError)
 
 
@@ -64,7 +64,7 @@ def test_serialization_error_is_not_a_connection_error() -> None:
 
 
 def test_transport_error_is_an_exception() -> None:
-    """TransportError sits under Exception so bare ``except`` does not swallow it."""
+    """TransportError sits under Exception, not BaseException."""
     assert issubclass(TransportError, Exception)
     assert not issubclass(TransportError, BaseException) or issubclass(
         TransportError, Exception


### PR DESCRIPTION
## Summary
- New `tinyros.transport._errors` defines the public hierarchy:
  - `TransportError(Exception)` — umbrella.
  - `ConnectionLost(TransportError, ConnectionError)` — peer is gone. MI from the builtin keeps `except ConnectionError` working for pre-hierarchy callers.
  - `SerializationError(TransportError)` — the wire payload could not be packed/unpacked.
- Re-exported from `tinyros.transport` and from `tinyros`.
- All `ConnectionError(...)` raises and `set_exception(...)` sites in `_client.py` switch to `ConnectionLost(...)`.
- `_encode_call` failures (e.g. unpicklable args) now surface as `SerializationError` on the returned future, instead of bare `TypeError` / `PickleError`.
- New `tests/test_transport_errors.py` covers the inheritance contract end-to-end and the encode-failure → `SerializationError` path.

## Why
Issue #44: ten `except Exception:` blocks in the transport layer were conflating "expected connection drop" with "serialization bug" with "real bug". Callers had nothing concrete to catch. This PR introduces the names and converts the user-visible raise sites; the remaining broad catches in `_server.py` are defensive and out of scope (see #45 and #48).

## Backward compatibility
- Existing tests using `pytest.raises(ConnectionError)` continue to pass — verified in CI by all 80 prior tests staying green.
- Anyone relying on the `TypeError` from publishing a non-picklable arg will see `SerializationError` instead. `SerializationError` is `Exception`-derived but not `TypeError`-derived; documented in the commit body.

## Test plan
- [x] 88 tests pass locally (8 new, 80 existing)
- [x] `pre-commit run --hook-stage push --all-files` passes
- [x] CI matrix passes on 3.10/3.11/3.12

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)
