### PR TITLE
fix(test): make main.py smoke test deterministic with goggles installed

### DIFF
--- a/src/tinyros/_logging.py
+++ b/src/tinyros/_logging.py
@@ -3,17 +3,28 @@
 Uses :mod:`goggles` when available (keeps parity with the broader ecosystem
 scopes / metrics), otherwise falls back to the standard library so that
 ``pip install tinyros`` does not pull a transitive dependency chain.
+
+Set ``TINYROS_LOG_FORCE_STDLIB=1`` in the environment to bypass goggles even
+when it is installed and use the stdlib logger directly. This exists for
+tests that capture subprocess stdout/stderr -- goggles emits through an
+async event bus whose output does not always survive ``subprocess.PIPE``.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 try:
     import goggles as _gg  # type: ignore[import-not-found]
 except ImportError:  # pragma: no cover - exercised in minimal installs
     _gg = None
+
+
+def _stdlib_forced() -> bool:
+    """Honor ``TINYROS_LOG_FORCE_STDLIB`` to bypass goggles when set."""
+    return os.environ.get("TINYROS_LOG_FORCE_STDLIB") in ("1", "true", "True")
 
 
 def get_logger(name: str, *, scope: str | None = None) -> Any:
@@ -27,7 +38,7 @@ def get_logger(name: str, *, scope: str | None = None) -> Any:
         A logger that exposes ``.info`` / ``.warning`` / ``.error`` /
         ``.debug`` methods.
     """
-    if _gg is not None:
+    if _gg is not None and not _stdlib_forced():
         return _gg.get_logger(name, scope=scope or name)
     return logging.getLogger(name)
 
@@ -47,7 +58,7 @@ def setup_console_logging(level: int = logging.INFO) -> None:
     Args:
         level: Minimum severity to emit. Defaults to INFO.
     """
-    if _gg is not None:
+    if _gg is not None and not _stdlib_forced():
         _gg.attach(_gg.ConsoleHandler(level=level), scopes=["tinyros"])
         return
     logging.basicConfig(

--- a/tests/test_main_smoke.py
+++ b/tests/test_main_smoke.py
@@ -66,6 +66,11 @@ def test_main_runs_and_shuts_down_cleanly() -> None:
     env = os.environ.copy()
     # Force unbuffered stdio so the parent sees logs in real time.
     env["PYTHONUNBUFFERED"] = "1"
+    # Bypass goggles for this subprocess: its async event bus does not
+    # route output through stdout/stderr in a way subprocess.PIPE can
+    # reliably capture, especially across mp-spawn children. The
+    # stdlib fallback writes synchronously and shows up in the pipe.
+    env["TINYROS_LOG_FORCE_STDLIB"] = "1"
 
     proc = subprocess.Popen(
         [sys.executable, str(_MAIN_PY)],


### PR DESCRIPTION
## Summary
- Add `TINYROS_LOG_FORCE_STDLIB` env var to `tinyros/_logging.py`. When set, `get_logger` and `setup_console_logging` bypass goggles even if it's installed and use the stdlib logger directly.
- `tests/test_main_smoke.py` sets that env var for its subprocess.

## Why
The smoke test added in #60 captures subprocess output via `subprocess.PIPE`, but goggles emits through an async event bus whose output does not reliably survive PIPE capture across mp-spawn children. The test passed in CI (Linux, plus the workflow doesn't run pytest) but failed deterministically on macOS once the dev env included goggles.

Production behavior is unchanged unless the env var is set.

## Test plan
- [x] `uv run pytest -q` passes 3× consecutively (was failing on the smoke test deterministically)
- [x] `pre-commit run --all-files` passes
- [x] `pre-commit run --hook-stage push --all-files` passes (pytest + basedpyright)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
