### PR TITLE
release: 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyros"
-version = "0.4.0"
+version = "0.4.1"
 description = "A minimal operating system for robotics."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/tinyros/__init__.py
+++ b/src/tinyros/__init__.py
@@ -18,7 +18,7 @@ from .transport import (
     TransportError,
 )
 
-__version__ = "0.3.1"
+__version__ = "0.4.1"
 __all__ = [
     "ConnectionLost",
     "SerializationError",

--- a/uv.lock
+++ b/uv.lock
@@ -3087,7 +3087,7 @@ wheels = [
 
 [[package]]
 name = "tinyros"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` to `0.4.1`.
- Sync `src/tinyros/__init__.py` `__version__` (was stuck at `0.3.1`).

## Milestone 0.4.1 contents
All 14 issues / 13 PRs in the [0.4.1 milestone](https://github.com/antonioterpin/tinyros/milestone/1) are merged.

## Test plan
- [x] `pre-commit run --all-files` passes
- [x] `pre-commit run --hook-stage push --all-files` passes (pytest + basedpyright)
- [ ] Tag `v0.4.1` after merge
- [ ] `python -m build` produces clean sdist + wheel
- [ ] `twine check dist/*` passes
- [ ] `twine upload dist/*` to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)