### PR TITLE
chore: merge dev into main (chaos tests + error-contract docs)

### DIFF
--- a/docs/guides/architecture/transport-error-contract.md
+++ b/docs/guides/architecture/transport-error-contract.md
@@ -103,19 +103,3 @@ should not page anyone, error lines should be investigated.
   does not print a traceback when a callback raises; it ships the
   exception. If you want a server-side log too, log inside the
   callback before re-raising.
-
----
-
-## Implementation pointers
-
-- Raise sites for `ConnectionLost`:
-  [`_client.py`](../../../src/tinyros/transport/_client.py).
-- Raise site for `SerializationError`:
-  [`_client.py`](../../../src/tinyros/transport/_client.py) (encode
-  path) and
-  [`_server.py`](../../../src/tinyros/transport/_server.py) (CALL
-  decode path).
-- Reader-loop classification:
-  [`TinyServer._reader_loop`](../../../src/tinyros/transport/_server.py).
-- Pool-submit classification:
-  [`TinyServer._submit_call`](../../../src/tinyros/transport/_server.py).

--- a/docs/guides/architecture/transport-error-contract.md
+++ b/docs/guides/architecture/transport-error-contract.md
@@ -1,0 +1,121 @@
+# Transport error contract
+
+What raises, what is logged, and what callers see when something goes
+wrong on the wire. Pair with
+[transport.md](transport.md) for the happy-path protocol and
+[transport-tunables.md](transport-tunables.md) for the knobs that shape
+the failure modes.
+
+The contract is intentionally narrow: **two failure shapes
+clients catch by type, plus the application's own exception** for
+callback failures. Everything else is a bug and is logged with a
+traceback.
+
+---
+
+## The exception hierarchy
+
+Defined in
+[`src/tinyros/transport/_errors.py`](../../../src/tinyros/transport/_errors.py)
+and re-exported as `tinyros.TransportError` /
+`tinyros.ConnectionLost` / `tinyros.SerializationError`:
+
+```text
+Exception
+├── TransportError                                  # base; catch-all
+│   ├── ConnectionLost (also ConnectionError)       # peer is gone
+│   └── SerializationError                          # wire payload bad
+└── (whatever the callback raised, on success-but-failed calls)
+```
+
+`ConnectionLost` multi-inherits from the builtin `ConnectionError`,
+so callers written before this hierarchy that catch `ConnectionError`
+keep working unchanged.
+
+---
+
+## Client-side: what futures resolve with
+
+Every `client.call(...)` returns a `concurrent.futures.Future`. After
+calling `.result()` on it, the caller sees one of:
+
+| Outcome | Future state | What you got |
+|---|---|---|
+| Callback ran and returned a value | `result` set | The return value (pickled and back). |
+| Callback raised | `exception` set | The original exception (pickled and back). |
+| Callback raised something un-picklable | `exception` set | A synthesized `RuntimeError` naming the original type. |
+| Encode failed before send (e.g., un-picklable arg) | `exception` set | `SerializationError`. |
+| Connection dropped or never established | `exception` set | `ConnectionLost`. |
+| Server is shutting down mid-call | `exception` set | `ConnectionLost`. |
+
+**Recommended catch pattern:**
+
+```python
+fut = client.call("topic", payload)
+try:
+    result = fut.result(timeout=2.0)
+except SerializationError:
+    # The payload itself is the problem. Retrying will not help.
+    ...
+except ConnectionLost:
+    # The peer is gone. Retry, reconnect, or escalate.
+    ...
+except concurrent.futures.TimeoutError:
+    # The peer accepted the call but did not reply in time.
+    ...
+except Exception:
+    # The remote callback raised. The exception you see here is
+    # whatever the callback raised, after a pickle round-trip.
+    ...
+```
+
+---
+
+## Server-side: how failures are logged
+
+Each row is a real code path; the log level reflects "is this the
+operator's problem to fix?".
+
+| Trigger | Log level | Action |
+|---|---|---|
+| Inbound CALL body is unparseable (`SerializationError`) | warning | Drop the connection. Peer sent garbage; not our bug. |
+| Inbound CALL_LARGE metadata unparseable | error | Synthesize a failure REPLY for the caller, drop the conn. |
+| Inbound CALL_LARGE shm materialization fails (segment missing) | error | Synthesize a failure REPLY, do not drop the conn. |
+| Callback raises an exception | (unlogged on server, propagated to caller) | The exception is shipped back as part of the REPLY frame. |
+| Callback's return value is un-picklable | warning | Substitute a `RuntimeError`; the caller sees that instead of hanging. |
+| `ThreadPoolExecutor.submit` returns `RuntimeError` | (unlogged) | Pool is shutting down; drop the slot silently. |
+| `ThreadPoolExecutor.submit` raises anything else | error + traceback | Re-raise after releasing the in-flight slot. This is a bug. |
+| Reader handler raises `SerializationError` | warning | Drop the connection. |
+| Reader handler raises anything else | error + traceback | Drop the connection. This is a bug. |
+| Reply socket write fails (`OSError`) | (silent) | Connection is gone; nothing to do. |
+
+The split between *warning* and *error* is the contract: warning lines
+should not page anyone, error lines should be investigated.
+
+---
+
+## What does **not** raise to the caller
+
+- **Reply-side `OSError`** when the socket is already closed -- the
+  server discards quietly. The client's recv loop will fail every
+  pending future with `ConnectionLost` once it notices the EOF.
+- **Server-side traceback for callback exceptions** -- the server
+  does not print a traceback when a callback raises; it ships the
+  exception. If you want a server-side log too, log inside the
+  callback before re-raising.
+
+---
+
+## Implementation pointers
+
+- Raise sites for `ConnectionLost`:
+  [`_client.py`](../../../src/tinyros/transport/_client.py).
+- Raise site for `SerializationError`:
+  [`_client.py`](../../../src/tinyros/transport/_client.py) (encode
+  path) and
+  [`_server.py`](../../../src/tinyros/transport/_server.py) (CALL
+  decode path).
+- Reader-loop classification:
+  [`TinyServer._reader_loop`](../../../src/tinyros/transport/_server.py).
+- Pool-submit classification:
+  [`TinyServer._submit_call`](../../../src/tinyros/transport/_server.py).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Single source of truth for all TinyROS documentation. Start here.
 | [overview.md](guides/architecture/overview.md) | Top-level layout, core concepts, where to make changes |
 | [transport.md](guides/architecture/transport.md) | Wire protocol, framing, shared-memory fast path, threading |
 | [transport-tunables.md](guides/architecture/transport-tunables.md) | Env vars, constructor args, and compile-time constants that govern transport behavior |
+| [transport-error-contract.md](guides/architecture/transport-error-contract.md) | Exception hierarchy, what each side logs, what the caller's future resolves with |
 | [tiny-objects.md](guides/architecture/tiny-objects.md) | Runtime behavior of TinyServer / TinyClient / TinyNode: state machines, backpressure, reconnect, failure modes |
 
 ---

--- a/src/tinyros/transport/_server.py
+++ b/src/tinyros/transport/_server.py
@@ -25,6 +25,7 @@ from ._common import (
     _logger,
     _PendingCall,
 )
+from ._errors import SerializationError
 from ._framing import (
     _frame,
     _materialize_call_large,
@@ -297,10 +298,21 @@ class TinyServer:
                     return
                 try:
                     self._handle_frame(conn, kind, body)
-                except Exception as exc:
-                    _logger.error(
-                        f"{self.name}: frame handler failed "
-                        f"(kind={kind}, peer_fd={conn.fileno()}): {exc}"
+                except SerializationError as exc:
+                    # Peer sent garbage we cannot decode. Drop the
+                    # connection but log at warning -- this is bad
+                    # input, not a server bug.
+                    _logger.warning(
+                        f"{self.name}: dropping peer (kind={kind}, "
+                        f"peer_fd={conn.fileno()}): {exc}"
+                    )
+                    return
+                except Exception:
+                    # Anything else is unexpected -- include the
+                    # traceback so the operator can find the bug.
+                    _logger.exception(
+                        f"{self.name}: frame handler crashed "
+                        f"(kind={kind}, peer_fd={conn.fileno()})"
                     )
                     return
         finally:
@@ -321,7 +333,13 @@ class TinyServer:
             body: Frame body bytes.
         """
         if kind == _MSG_CALL:
-            req_id, cb_name, arg = _unpack_oob(body)
+            try:
+                req_id, cb_name, arg = _unpack_oob(body)
+            except Exception as exc:
+                raise SerializationError(
+                    f"tinyros server {self.name!r}: failed to decode CALL "
+                    f"frame: {type(exc).__name__}: {exc}"
+                ) from exc
             pending = _PendingCall(conn, int(req_id), str(cb_name), arg)
             self._submit_call(self._execute_call, pending)
         elif kind == _MSG_CALL_LARGE:
@@ -350,13 +368,21 @@ class TinyServer:
         try:
             fut = self._pool.submit(fn, *args)
         except RuntimeError:
-            # Pool is shutting down (expected during close()); drop the
-            # slot and the call. Reader loop will notice _running fall
-            # and exit on its own without logging a spurious error.
+            # ThreadPoolExecutor.submit() raises RuntimeError exactly
+            # when the pool is shut down. Expected during close():
+            # drop the slot and the call; the reader loop will notice
+            # _running fall and exit on its own without logging a
+            # spurious error.
             self._pool_semaphore.release()
             return
         except Exception:
+            # Anything else from submit() is unexpected. Release the
+            # slot we just acquired and surface the traceback so an
+            # operator can find the bug; previously this re-raised
+            # silently and got conflated with deserialization failures
+            # at the reader loop's catch-site.
             self._pool_semaphore.release()
+            _logger.exception(f"{self.name}: unexpected error submitting work to pool")
             raise
         fut.add_done_callback(lambda _f: self._pool_semaphore.release())
 

--- a/tests/test_transport_chaos.py
+++ b/tests/test_transport_chaos.py
@@ -1,0 +1,180 @@
+"""Chaos / fault-injection tests for the transport layer.
+
+Exercises failure paths that pure happy-path tests cannot reach:
+backpressure under a saturated worker pool, an abrupt mid-call client
+disconnect, and the server logging contract when a frame handler
+crashes with a non-:class:`SerializationError` exception.
+
+Pairs with the typed exception hierarchy (#44) and the reader-loop
+classification (#45). Each test uses a short timeout (<3 s) and a
+fresh port so the suite stays bounded.
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+import threading
+import time
+
+import pytest
+
+from tests.conftest import wait_port_free
+from tinyros.transport import TinyClient, TinyServer
+
+
+def test_slow_callback_does_not_starve_pool(free_port: int) -> None:
+    """A slow callback must not block other concurrent calls indefinitely.
+
+    Bind two callbacks to the same server: ``slow`` blocks for 0.5 s,
+    ``fast`` returns immediately. Issue a burst of slow calls that
+    saturates ``workers`` and then a single fast call. The fast call
+    must complete before the last slow one -- otherwise the reader is
+    serializing rather than running concurrently.
+    """
+    workers = 4
+    server = TinyServer(
+        name="t-chaos-slow",
+        host="127.0.0.1",
+        port=free_port,
+        workers=workers,
+    )
+    server.bind("slow", lambda _x: (time.sleep(0.3), "ok")[1])
+    server.bind("fast", lambda _x: "ok")
+    server.start(block=False)
+    client = TinyClient(host="127.0.0.1", port=free_port, name="t-chaos-cli")
+    try:
+        slow_futs = [client.call("slow", i) for i in range(workers)]
+        # Submit fast right after; with concurrent execution it should
+        # land in workers' time. With serial execution it would have
+        # to wait for all slow calls to drain.
+        t0 = time.monotonic()
+        fast_fut = client.call("fast", None)
+        assert fast_fut.result(timeout=2.0) == "ok"
+        fast_elapsed = time.monotonic() - t0
+        # Each slow call is 0.3 s. With concurrent dispatch the fast
+        # call should resolve in well under the 0.3 s slow window;
+        # tolerate scheduling jitter.
+        assert fast_elapsed < 0.6, (
+            f"fast call took {fast_elapsed:.2f}s; pool appears to be "
+            f"serializing slow callbacks"
+        )
+        # Drain slow ones so close() does not stall on the pool.
+        for fut in slow_futs:
+            assert fut.result(timeout=2.0) == "ok"
+    finally:
+        client.close(timeout=1.0)
+        server.close(timeout=2.0)
+        wait_port_free(free_port)
+
+
+def test_partial_header_disconnect_does_not_crash_server(free_port: int) -> None:
+    """A client that closes its TCP socket mid-header must not crash the server.
+
+    Open a raw socket, send half a frame header, then orderly-close.
+    The server's reader loop should drop the connection cleanly; a
+    legitimate client must still be able to issue calls afterwards.
+    """
+    server = TinyServer(name="t-chaos-abrupt", host="127.0.0.1", port=free_port)
+    server.bind("noop", lambda x: x)
+    server.start(block=False)
+    try:
+        raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        raw.connect(("127.0.0.1", free_port))
+        # 2 bytes of a 5-byte (u8 + u32) header.
+        raw.sendall(b"\x01\x00")
+        raw.close()
+
+        # Give the server's reader loop a moment to observe the EOF
+        # and drop the connection. _READ_POLL_S is 1.0, so 1.5 s is
+        # the sound floor.
+        time.sleep(1.5)
+
+        # Legitimate client still works after the bad peer is dropped.
+        good = TinyClient(host="127.0.0.1", port=free_port, name="t-chaos-good-cli")
+        try:
+            assert good.call("noop", 7).result(timeout=2.0) == 7
+        finally:
+            good.close(timeout=1.0)
+    finally:
+        server.close(timeout=1.0)
+        wait_port_free(free_port)
+
+
+def test_handler_crash_drops_conn_and_keeps_server_alive(free_port: int) -> None:
+    """An unexpected handler crash must drop the conn but not the server.
+
+    Patch ``_handle_frame`` to raise a non-:class:`SerializationError`.
+    The reader loop should treat it as a server bug (error-level path
+    in #45), drop the connection, and keep the server itself alive so
+    a fresh client can still get served.
+    """
+    server = TinyServer(name="t-chaos-crash", host="127.0.0.1", port=free_port)
+    server.bind("noop", lambda x: x)
+    server.start(block=False)
+
+    original_handle = server._handle_frame  # noqa: SLF001
+    crashed = threading.Event()
+
+    def crashing_handle(*_args: object, **_kwargs: object) -> None:
+        crashed.set()
+        raise RuntimeError("synthetic handler bug")
+
+    server._handle_frame = crashing_handle  # type: ignore[method-assign]  # noqa: SLF001
+
+    client = TinyClient(host="127.0.0.1", port=free_port, name="t-chaos-crash-cli")
+    try:
+        fut = client.call("noop", 1)
+        with pytest.raises(ConnectionError):
+            fut.result(timeout=2.0)
+        assert crashed.is_set(), "crashing_handle never ran"
+        client.close(timeout=1.0)
+
+        # Restore the real handler and verify the server still serves.
+        server._handle_frame = original_handle  # type: ignore[method-assign]  # noqa: SLF001
+        good = TinyClient(host="127.0.0.1", port=free_port, name="t-chaos-after-cli")
+        try:
+            assert good.call("noop", 9).result(timeout=2.0) == 9
+        finally:
+            good.close(timeout=1.0)
+    finally:
+        server._handle_frame = original_handle  # type: ignore[method-assign]  # noqa: SLF001
+        server.close(timeout=1.0)
+        wait_port_free(free_port)
+
+
+def test_oversized_frame_drops_connection(free_port: int) -> None:
+    """A frame whose declared length exceeds ``max_frame_bytes`` is rejected.
+
+    Confirms that misbehaving peers cannot trigger an unbounded
+    allocation: the server logs and drops the conn, then a fresh
+    client must still be able to call.
+    """
+    cap = 1024  # 1 KiB cap; well below any real payload.
+    server = TinyServer(
+        name="t-chaos-oversized",
+        host="127.0.0.1",
+        port=free_port,
+        max_frame_bytes=cap,
+    )
+    server.bind("noop", lambda x: x)
+    server.start(block=False)
+    try:
+        # Hand-build a header claiming a 1 MiB body; never send the
+        # body. Server should detect length>cap before any allocation.
+        raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        raw.connect(("127.0.0.1", free_port))
+        # _HEADER_FMT = "!BI" (kind=u8, length=u32). kind=1 (CALL),
+        # length=1<<20. The bogus length must be > cap.
+        raw.sendall(struct.pack("!BI", 1, 1 << 20))
+        raw.close()
+
+        # Fresh client still works after the bad peer is dropped.
+        good = TinyClient(host="127.0.0.1", port=free_port, name="t-chaos-after-cli")
+        try:
+            assert good.call("noop", 42).result(timeout=2.0) == 42
+        finally:
+            good.close(timeout=1.0)
+    finally:
+        server.close(timeout=1.0)
+        wait_port_free(free_port)

--- a/tests/test_transport_rpc.py
+++ b/tests/test_transport_rpc.py
@@ -854,6 +854,38 @@ def test_call_large_corrupt_metadata_drops_connection(free_port: int) -> None:
         wait_port_free(free_port)
 
 
+def test_corrupt_call_body_drops_connection(free_port: int) -> None:
+    """A CALL frame whose body fails to unpack must drop the peer.
+
+    Companion to ``test_call_large_corrupt_metadata_drops_connection``
+    for the small-payload path: ``_handle_frame`` now wraps the
+    ``_unpack_oob`` failure in :class:`SerializationError`, which the
+    reader loop classifies as bad input (warning log, drop the conn)
+    rather than a server bug. The client must see its pending future
+    fail in bounded time.
+    """
+    from tinyros.transport import _frame  # type: ignore[attr-defined]
+    from tinyros.transport._common import _MSG_CALL  # noqa: SLF001
+
+    server = TinyServer(name="t-corrupt-call", host="127.0.0.1", port=free_port)
+    server.bind("noop", lambda _x: None)
+    server.start(block=False)
+    client = TinyClient(host="127.0.0.1", port=free_port, name="t-corrupt-call-cli")
+    try:
+        bogus = _frame(_MSG_CALL, b"\x00not a pickle\x00")
+        fut: concurrent.futures.Future = concurrent.futures.Future()
+        with client._pending_lock:  # noqa: SLF001
+            client._pending[54321] = fut  # noqa: SLF001
+        client._send_queue.put((bogus, None))  # noqa: SLF001
+
+        with pytest.raises(ConnectionError):
+            fut.result(timeout=2.0)
+    finally:
+        client.close(timeout=1.0)
+        server.close(timeout=1.0)
+        wait_port_free(free_port)
+
+
 def test_pending_futures_fail_on_send_failure(free_port: int) -> None:
     """When ``_send_loop`` hits ``OSError``, every pending future must
     resolve with ``ConnectionError`` rather than hang.


### PR DESCRIPTION
## Summary
Bring two PRs that landed on `dev` but never reached `main`:

- **#63** docs(transport): add error contract reference
- **#64** test(chaos): add fault-injection coverage for transport
- (plus the small in-PR fixup `a19da1a` that dropped the unmaintainable implementation-pointers section in #63)

Both were part of the 0.4.1 milestone but merged into `dev` after I retargeted them; the release PR #68 was cut from `main`, so the 0.4.1 sdist / wheel built from `main` HEAD does **not** contain them. This PR fixes that.

## Why a merge commit
`main` already has the release-version-bump commit (`12a4aa4`); `dev` does not. The two histories have diverged, so a merge commit is the right primitive — rebasing `dev` would rewrite the merged-PR commits.

## After merge
- Re-tag `v0.4.1` at the new `main` HEAD (any prior `v0.4.1` tag is now stale).
- Then build + `twine upload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
