### PR TITLE
docs(benchmarks): centralize benchmark tutorials in docs/guides/benchmarks.md

### DIFF
--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -1,0 +1,177 @@
+# Benchmarks
+
+Latency and throughput benchmarks for TinyROS, with parity baselines against
+[`portal`](https://pypi.org/project/portal/) and ROS 2.
+
+The benchmark suite lives in [`tests/benchmark/`](../../tests/benchmark/) and is
+gated behind the `run_explicitly` pytest mark so the default test suite stays
+fast.
+
+```bash
+uv run pytest -m run_explicitly tests/benchmark/
+```
+
+---
+
+## Suites
+
+| Suite | Path | Optional dependency | Install |
+|---|---|---|---|
+| TinyROS (native) | [`tests/benchmark/tinyros/`](../../tests/benchmark/tinyros/) | none | core install is enough |
+| Portal parity | [`tests/benchmark/portal/`](../../tests/benchmark/portal/), [`tests/benchmark/test_publish_fn_speed.py`](../../tests/benchmark/test_publish_fn_speed.py) | [`portal`](https://pypi.org/project/portal/) | `uv sync --extra portal` |
+| ROS 2 baseline | [`tests/benchmark/ros2/`](../../tests/benchmark/ros2/) | ROS 2 Humble (conda) | see [ROS 2 baseline](#ros-2-baseline) |
+
+The portal suites call `pytest.importorskip("portal")`, so running them without
+the `[portal]` extra yields a clean skip rather than a collection error. The
+ROS 2 directory is excluded from default collection via `norecursedirs` in
+`pyproject.toml`.
+
+---
+
+## TinyROS native suite
+
+### Two-process round-trip benchmark
+
+[`tests/benchmark/tinyros/test_speed_interprocess.py`](../../tests/benchmark/tinyros/test_speed_interprocess.py)
+
+Spawns a subscriber process and a publisher process (the pytest worker),
+measures per-message round-trip latency across a small matrix of payload types
+and sizes, and reports min / median / p50 / p95 / p99 / max / mean / stdev.
+
+**Design** -- mirrors the goggles `examples/105_benchmark.py` design:
+
+- every payload category is isolated in its own process pair so the transport
+  state does not leak between cases;
+- scalars, strings, bytes, and ndarray sweeps (CPU only) are covered;
+- ndarray sizes span both the inline (< 64 KiB) and the shared-memory
+  (>= 64 KiB) code paths, so the shm fast path can be observed kicking in.
+
+**Correctness instrumentation** (added on top of the latency bench):
+
+- every iteration `i` builds a payload that encodes `i` as a *pattern* in a
+  type-specific way (leading decimal digits for strings/bytes, `arr.flat[0]`
+  for ndarrays, the value itself for scalars);
+- the subscriber's callback decodes `i` from the incoming payload, increments
+  a monotonic counter, and returns `(i, counter)`;
+- the publisher asserts both fields on every reply -- so per-message content
+  correctness *and* end-to-end delivery count are verified without adding
+  significant measurement overhead (the assertions run after `future.result()`,
+  outside the timed region).
+
+**Run:**
+
+```bash
+uv run pytest -m run_explicitly \
+    tests/benchmark/tinyros/test_speed_interprocess.py -s
+```
+
+### CPU/GPU payload sweep
+
+[`tests/benchmark/tinyros/test_speed_tinyros.py`](../../tests/benchmark/tinyros/test_speed_tinyros.py)
+
+Benchmarks tinyros message passing speed across CPU and GPU payloads.
+
+**Run:**
+
+```bash
+uv run pytest -m run_explicitly tests/benchmark/tinyros/test_speed_tinyros.py
+```
+
+---
+
+## Portal parity suite
+
+Comparison runs that use the same harness against [`portal`](https://pypi.org/project/portal/).
+
+### Install
+
+Requires the optional `[portal]` extra:
+
+```bash
+uv sync --extra portal
+# or
+pip install -e '.[portal]'
+```
+
+### CPU/GPU payload sweep
+
+[`tests/benchmark/portal/test_speed_portal.py`](../../tests/benchmark/portal/test_speed_portal.py)
+
+Mirrors the TinyROS CPU/GPU sweep against portal's transport.
+
+```bash
+uv run pytest -m run_explicitly tests/benchmark/portal/test_speed_portal.py
+```
+
+### `publish()` latency under a slow subscriber
+
+[`tests/benchmark/test_publish_fn_speed.py`](../../tests/benchmark/test_publish_fn_speed.py)
+
+Measures `publish()` latency in the publisher worker while a separate
+subscriber worker sleeps inside its callback.
+
+- Worker A: slow subscriber (sleep inside callback)
+- Worker B: fast publisher measuring `publish()` latency
+
+Despite the `test_` filename this is a runnable script, not a pytest test.
+When collected by pytest it is skipped cleanly if `portal` is not installed
+(only `portal.Process` is used, to spawn the subscriber worker).
+
+**Run:**
+
+```bash
+GOGGLES_PORT=8374 uv run python -m \
+    tests.benchmark.test_publish_fn_speed \
+    --num-msgs 15000 --sleep-ms 100 --wandb
+```
+
+---
+
+## ROS 2 baseline
+
+[`tests/benchmark/ros2/`](../../tests/benchmark/ros2/) measures end-to-end
+message latency using **ROS 2** (publisher -> subscriber) for different
+payload sizes. It is intended as a baseline for comparison with the TinyROS
+and portal suites above.
+
+### Install ROS 2
+
+Install the dependencies **in the order below**:
+
+#### Create a dedicated conda environment
+
+```bash
+conda create -n ros2-bench python=3.10
+conda activate ros2-bench
+```
+
+#### Install Python requirements for the benchmark
+
+```bash
+pip install -r tests/benchmark/ros2/requirements.txt
+```
+
+#### Install ROS 2
+
+Add the following channels to the environment:
+
+```bash
+conda config --env --add channels conda-forge
+conda config --env --add channels robostack-staging
+conda config --env --remove channels defaults
+```
+
+Then install ROS 2:
+
+```bash
+conda install ros-humble-desktop
+conda deactivate
+conda activate ros2-bench
+```
+
+### Run
+
+```bash
+python -m tests.benchmark.ros2.test_runner_singleprocess
+python -m tests.benchmark.ros2.test_runner_multiprocess
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Single source of truth for all TinyROS documentation. Start here.
 | [contributing.md](guides/contributing.md) | Development setup, quality gates, PR preparation |
 | [agent-development.md](guides/agent-development.md) | Using TinyROS with Claude Code, Antigravity, and custom agents |
 | [troubleshooting.md](guides/troubleshooting.md) | Common operational failure modes (stuck nodes, leaked shm, port reuse) and how to fix them |
+| [benchmarks.md](guides/benchmarks.md) | TinyROS / portal / ROS 2 benchmark suites: install, design notes, run commands |
 
 ---
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,29 +17,9 @@ Mirrors `src/tinyros/` so each test file maps to the module it covers.
 ROS 2. They are gated behind the `run_explicitly` pytest mark so the
 default suite stays fast.
 
-```bash
-uv run pytest -m run_explicitly tests/benchmark/
-```
-
-### Optional benchmark dependencies
-
-| Suite | Path | Extra dependency | Install |
-|---|---|---|---|
-| TinyROS (native) | `benchmark/tinyros/` | none (core install is enough) | — |
-| Portal comparison | `benchmark/portal/`, `benchmark/test_publish_fn_speed.py` | [`portal`](https://pypi.org/project/portal/) | `uv sync --extra portal` or `pip install -e '.[portal]'` |
-| ROS 2 comparison | `benchmark/ros2/` | ROS 2 Humble (conda) | see [`benchmark/ros2/ROS2.md`](benchmark/ros2/ROS2.md) |
-
-The portal benchmark tests call `pytest.importorskip("portal")`, so
-running them without the `[portal]` extra yields a clean skip rather
-than a collection error. The ROS 2 directory is excluded from default
-collection via `norecursedirs` in `pyproject.toml`.
-
-To run only the portal parity benchmarks:
-
-```bash
-uv sync --extra portal
-uv run pytest -m run_explicitly tests/benchmark/portal/
-```
+See [`docs/guides/benchmarks.md`](../docs/guides/benchmarks.md) for the
+suite overview, install instructions, design notes, and per-benchmark run
+commands.
 
 ## Conventions
 

--- a/tests/benchmark/portal/test_speed_portal.py
+++ b/tests/benchmark/portal/test_speed_portal.py
@@ -1,17 +1,9 @@
-"""Benchmark tests for portal message passing speed with CPU/GPU payloads.
+"""Portal parity benchmark: same harness as the TinyROS CPU/GPU sweep.
 
-Requires the optional ``[portal]`` extra::
+Skipped cleanly via ``pytest.importorskip`` when the optional ``[portal]``
+extra is not installed.
 
-    uv sync --extra portal
-    # or
-    pip install -e '.[portal]'
-
-Run with::
-
-    pytest -m run_explicitly tests/benchmark/portal/test_speed_portal.py
-
-If ``portal`` is not installed the module is skipped cleanly via
-``pytest.importorskip``.
+See ``docs/guides/benchmarks.md`` for install and run instructions.
 """
 
 from __future__ import annotations

--- a/tests/benchmark/ros2/ROS2.md
+++ b/tests/benchmark/ros2/ROS2.md
@@ -1,51 +1,6 @@
-# ROS 2 Latency Benchmark
+# ROS 2 latency benchmark
 
-This benchmark measures end-to-end message latency using **ROS 2**
-(publisher -> subscriber) for different payload sizes.
+Install and run instructions for the ROS 2 baseline benchmark have moved to the
+central benchmarks guide:
 
-It is intended as a baseline for comparison with the TinyROS and Portal
-benchmarks in this repository.
-
----
-
-## Install ROS2
-   Install the necessary dependencies **in the order below**:
-
-   ### Create a dedicated conda environment
-
-   ```bash
-   conda create -n ros2-bench python=3.10
-   conda activate ros2-bench
-   ```
-
-   ### Install Python requirements for the benchmark
-
-   ```bash
-   pip install -r benchmark_ros2/requirements.txt
-   ```
-
-   ### Install ROS 2
-
-   Add the following channels to the environment:
-
-   ```bash
-   conda config --env --add channels conda-forge
-   conda config --env --add channels robostack-staging
-   conda config --env --remove channels defaults
-   ```
-
-   Then, install ROS2 as follows:
-
-   ```bash
-   conda install ros-humble-desktop
-   conda deactivate
-   conda activate ros2-bench
-   ```
-
-   ### Run benchmark
-
-   To run the benchmarks use these lines:
-   ```bash
-   python -m tests.benchmark.ros2.test_runner_singleprocess
-   python -m tests.benchmark.ros2.test_runner_multiprocess
-   ```
+- [docs/guides/benchmarks.md](../../../docs/guides/benchmarks.md#ros-2-baseline)

--- a/tests/benchmark/test_publish_fn_speed.py
+++ b/tests/benchmark/test_publish_fn_speed.py
@@ -1,29 +1,9 @@
-r"""Benchmark TinyROS communication behavior.
+"""Measure ``publish()`` latency while a separate subscriber worker blocks.
 
-Goal:
-- Worker A: slow subscriber (sleep inside callback)
-- Worker B: fast publisher measuring publish() latency
+Despite the ``test_`` filename this is a runnable script, not a pytest test;
+it is skipped cleanly if the optional ``[portal]`` extra is not installed.
 
-Requires the optional ``[portal]`` extra (only ``portal.Process`` is used,
-to spawn the subscriber worker)::
-
-    uv sync --extra portal
-    # or
-    pip install -e '.[portal]'
-
-
-
-Usage:
-
-.. code-block:: console
-
-    $ GOGGLES_PORT=8374 uv run python -m \
-        tests.benchmark.test_publish_fn_speed \
-        --num-msgs 15000 --sleep-ms 100 --wandb
-
-Despite the ``test_`` filename this is a runnable script, not a pytest
-test. When collected by pytest it is skipped cleanly if ``portal`` is
-not installed.
+See ``docs/guides/benchmarks.md`` for install and run instructions.
 """
 
 from __future__ import annotations

--- a/tests/benchmark/tinyros/test_speed_interprocess.py
+++ b/tests/benchmark/tinyros/test_speed_interprocess.py
@@ -1,35 +1,11 @@
-r"""Two-process TinyROS transport benchmark.
+"""Two-process TinyROS round-trip latency benchmark with content verification.
 
-Spawns a subscriber process and a publisher process (the pytest worker),
-measures per-message round-trip latency across a small matrix of payload
-types and sizes, and reports min / median / p50 / p95 / p99 / max / mean
-/ stdev.
+Verifies that per-message round-trip latency stays bounded across a matrix of
+payload types and sizes, and that every payload round-trips byte-identically
+with no dropped or reordered messages.
 
-Mirrors the goggles ``examples/105_benchmark.py`` design:
-
-- every payload category is isolated in its own process pair so the
-  transport state does not leak between cases;
-- scalars, strings, bytes, and ndarray sweeps (CPU only) are covered;
-- ndarray sizes span both the inline (< 64 KiB) and the shared-memory
-  (>= 64 KiB) code paths, so we can see the shm fast path kick in.
-
-Correctness instrumentation (added on top of the latency bench):
-
-- every iteration ``i`` builds a payload that encodes ``i`` as a
-  *pattern* in a type-specific way (leading decimal digits for
-  strings/bytes, ``arr.flat[0]`` for ndarrays, the value itself for
-  scalars);
-- the subscriber's callback decodes ``i`` from the incoming payload,
-  increments a monotonic counter, and returns ``(i, counter)``;
-- the publisher asserts both fields on every reply -- so we verify
-  per-message content correctness *and* end-to-end delivery count
-  without adding significant measurement overhead (the assertions run
-  after ``future.result()``, outside the timed region).
-
-Run with::
-
-    uv run pytest -m run_explicitly \
-        tests/benchmark/tinyros/test_speed_interprocess.py -s
+See ``docs/guides/benchmarks.md`` for design notes (payload categories,
+isolation, correctness instrumentation) and run instructions.
 """
 
 from __future__ import annotations

--- a/tests/benchmark/tinyros/test_speed_tinyros.py
+++ b/tests/benchmark/tinyros/test_speed_tinyros.py
@@ -1,6 +1,6 @@
-"""Benchmark tests for tinyros message passing speed with CPU/GPU payloads.
+"""Benchmark TinyROS message-passing throughput across CPU and GPU payloads.
 
-Run with: pytest -m run_explicitly tests/benchmark/tinyros/test_speed_tinyros.py
+See ``docs/guides/benchmarks.md`` for run instructions.
 """
 
 import csv


### PR DESCRIPTION
## Summary

- Add `docs/guides/benchmarks.md` consolidating suite overview, install instructions, design notes, and per-benchmark run commands for the TinyROS, portal, and ROS 2 baseline suites.
- Trim the four benchmark module docstrings (`test_publish_fn_speed.py`, `tinyros/test_speed_interprocess.py`, `tinyros/test_speed_tinyros.py`, `portal/test_speed_portal.py`) to a single-paragraph "what this verifies" summary that points to the new guide.
- Replace `tests/benchmark/ros2/ROS2.md` with a short redirect; link the new guide from `docs/index.md` and shorten `tests/README.md` to point at it.

Out of scope: the chaos / smoke / deadlock / race-condition docstrings in non-benchmark tests -- those describe what the test verifies and are correctly placed.

Closes #70

## Test plan

- [x] `uv run pre-commit run --files <changed>` passes
- [x] `uv run pre-commit run --hook-stage push --files <changed>` passes (pytest + basedpyright)
- [x] `uv run pytest --collect-only tests/benchmark/` collects 89 tests cleanly with the trimmed docstrings
- [x] Reviewer: skim `docs/guides/benchmarks.md` and confirm nothing was lost vs. the prior docstrings + `ROS2.md`
