### PR TITLE
refactor(version): derive __version__ from package metadata

### DIFF
--- a/src/tinyros/__init__.py
+++ b/src/tinyros/__init__.py
@@ -3,6 +3,9 @@
 Nothing outside of this module's ``__all__`` is considered public.
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
+
 from ._logging import get_logger, setup_console_logging
 from .node import (
     TinyNetworkConfig,
@@ -18,7 +21,10 @@ from .transport import (
     TransportError,
 )
 
-__version__ = "0.4.1"
+try:
+    __version__ = _version("tinyros")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 __all__ = [
     "ConnectionLost",
     "SerializationError",


### PR DESCRIPTION
## Summary

- Drive `tinyros.__version__` from `importlib.metadata.version("tinyros")` so `pyproject.toml` is the single source of truth.
- Eliminates the kind of drift that bit us with v0.4.1 (source said `0.2.2`, PyPI shipped `0.4.1`).

## Notes

- `pyproject.toml` and `__init__.py` were already manually bumped to `0.4.1` on `main`, so this is the structural follow-up: prevent the next drift rather than fix the current one.
- Falls back to `"0.0.0+unknown"` only in the (unusual) case the package isn't installed, e.g. running directly from a source tree without `pip install -e .` / `uv sync`.

## Test plan

- [x] `uv run python -c "import tinyros; print(tinyros.__version__)"` → `0.4.1`
- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes (94 passed, coverage 84.52%)

Closes #73.
