### PR TITLE
chore(packaging): modernize pyproject and move contributor deps to groups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
-This page summarizes the development workflow and software engineering practices adopted in this codebase. This project is written in Python 3.11+ and uses JAX/Flax.
+This page summarizes the development workflow and software engineering practices adopted in this codebase. This project targets Python 3.10+.
 
 - [Development workflow](#development-workflow)
 - [Testing a feature](#testing-a-feature)
@@ -14,11 +14,8 @@ This page summarizes the development workflow and software engineering practices
 ├── src/                    # Source code
 ├── tests/                  # Test suite
 ├── docs/                   # Documentation
-├── scripts/                # Utils, like custom hooks
 ├── .pre-commit-config.yaml # Code quality hooks
 ├── pyproject.toml          # Project configuration
-├── Dockerfile              # Container setup
-├── docker-compose.yaml     # Development containers
 └── CONTRIBUTING.md         # Development guidelines
 ```
 
@@ -28,9 +25,14 @@ If you do not have it yet, install it with:
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-To provision the local environment with development tools only:
+To provision the local environment with development tools:
 ```sh
-uv sync --extra dev
+uv sync --group dev
+```
+
+To additionally install the comparison benchmarks (JAX, portal):
+```sh
+uv sync --group dev --group benchmark
 ```
 
 Run the application with (see the [README.md](README.md) for details on the usage):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,15 +7,25 @@ name = "tinyros"
 version = "0.4.1"
 description = "A minimal operating system for robotics."
 readme = "README.md"
-license = { text = "MIT" }
-urls = { Homepage = "https://github.com/antonioterpin/tinyros" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
-    { name = "Antonio Terpin", email = "aterpin@ethz.ch" },
+    { name = "Antonio Terpin", email = "antonio.terpin@gmail.com" },
 ]
+keywords = ["robotics", "ros", "pubsub", "rpc", "ipc"]
 classifiers = [
-  "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: MIT License",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
   "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: System :: Distributed Computing",
+  "Typing :: Typed",
 ]
 requires-python = ">=3.10"
 
@@ -29,36 +39,30 @@ dependencies = [
     "numpy>=1.24.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/antonioterpin/tinyros"
+Source = "https://github.com/antonioterpin/tinyros"
+Issues = "https://github.com/antonioterpin/tinyros/issues"
+Changelog = "https://github.com/antonioterpin/tinyros/releases"
+
 [tool.uv.sources]
 # uv-only hint: dev environments pick up the dev branch of goggles.
 # Stripped from the published wheel's metadata -- end users installing
 # from PyPI never see this line.
 robo-goggles = { git = "https://github.com/antonioterpin/goggles.git", branch = "dev" }
 
-# Optional dependencies
+# Public optional dependencies (advertised on PyPI as `tinyros[<name>]`).
+# Contributor-only deps live in `[dependency-groups]` below so they don't
+# leak into the published wheel's metadata.
 [project.optional-dependencies]
-dev = [
-    "matplotlib>=3.10.8",
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-    "hypothesis>=6.0.0",
-    "pre_commit==4.0.1",
-    "basedpyright>=1.37.1",
-    "robo-goggles[wandb,jax]",
-]
 # Opt-in structured logging via goggles. Core tinyros works without it.
 logging = [
     "robo-goggles",
 ]
-# Optional: only needed to run the comparison benchmarks under
-# tests/benchmark/portal/ and tests/benchmark/test_publish_fn_speed.py.
-# Install with: `uv sync --extra portal` or `pip install -e '.[portal]'`.
-portal = [
-    "portal>=0.1.0",
-]
-benchmark = [
-    "jax[cuda12]>=0.6.2",  # keep only the GPU override
-]
+
+# Ship the py.typed marker so type-checkers consume the package's types.
+[tool.setuptools.package-data]
+tinyros = ["py.typed"]
 
 # Pytest configuration
 [tool.pytest.ini_options]
@@ -138,10 +142,25 @@ typeCheckingMode = "basic"
 reportMissingImports = false
 reportMissingTypeStubs = false
 
+# Contributor-only dependency groups (PEP 735). Not advertised on PyPI.
+# Install with `uv sync --group <name>`.
 [dependency-groups]
 dev = [
+    "matplotlib>=3.10.8",
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "hypothesis>=6.0.0",
+    "pre_commit==4.0.1",
+    "basedpyright>=1.37.1",
+    "robo-goggles[wandb,jax]",
     "build>=1.3.0",
     "twine>=6.2.0",
+]
+# Comparison benchmarks under tests/benchmark/portal/ and the JAX-driven
+# load generators under tests/benchmark/{portal,tinyros}/.
+benchmark = [
+    "jax[cuda12]>=0.6.2",
+    "portal>=0.1.0",
 ]
 
 # Bandit static security scan. Pickle deserialization (B301, B403) is

--- a/uv.lock
+++ b/uv.lock
@@ -3096,52 +3096,50 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+logging = [
+    { name = "robo-goggles" },
+]
+
+[package.dev-dependencies]
 benchmark = [
     { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version < '3.11'" },
     { name = "jax", version = "0.8.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version >= '3.11'" },
+    { name = "portal" },
 ]
 dev = [
     { name = "basedpyright" },
+    { name = "build" },
     { name = "hypothesis" },
     { name = "matplotlib" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "robo-goggles", extra = ["jax", "wandb"] },
-]
-logging = [
-    { name = "robo-goggles" },
-]
-portal = [
-    { name = "portal" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "build" },
     { name = "twine" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.37.1" },
-    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "jax", extras = ["cuda12"], marker = "extra == 'benchmark'", specifier = ">=0.6.2" },
-    { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=1.24.0" },
-    { name = "portal", marker = "extra == 'portal'", specifier = ">=0.1.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.0.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "robo-goggles", marker = "extra == 'logging'", git = "https://github.com/antonioterpin/goggles.git?branch=dev" },
-    { name = "robo-goggles", extras = ["wandb", "jax"], marker = "extra == 'dev'", git = "https://github.com/antonioterpin/goggles.git?branch=dev" },
 ]
-provides-extras = ["dev", "logging", "portal", "benchmark"]
+provides-extras = ["logging"]
 
 [package.metadata.requires-dev]
+benchmark = [
+    { name = "jax", extras = ["cuda12"], specifier = ">=0.6.2" },
+    { name = "portal", specifier = ">=0.1.0" },
+]
 dev = [
+    { name = "basedpyright", specifier = ">=1.37.1" },
     { name = "build", specifier = ">=1.3.0" },
+    { name = "hypothesis", specifier = ">=6.0.0" },
+    { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "pre-commit", specifier = "==4.0.1" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "robo-goggles", extras = ["wandb", "jax"], git = "https://github.com/antonioterpin/goggles.git?branch=dev" },
     { name = "twine", specifier = ">=6.2.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Move contributor-only deps (`dev`, `portal`, `benchmark`) from `[project.optional-dependencies]` to `[dependency-groups]` so they no longer leak into the published wheel as `tinyros[portal]` / `tinyros[dev]`. The public `logging` extra stays.
- Modernize PyPI metadata: PEP 639 license, expanded classifiers / urls / keywords, `py.typed` marker, author email synced with git authorship.
- Update `CONTRIBUTING.md` to match: drop wrong "Python 3.11+ / JAX/Flax" claim, document `uv sync --group dev` / `--group benchmark`, remove stale Docker references.

## Why

The `tinyros[portal]` extra was advertised on PyPI but `portal` is only imported from `tests/benchmark/`. End users saw a backend that didn't ship. Likewise the `dev` extra leaked dev-only tooling into wheel metadata. PEP 735 dependency groups are the right home for both.

## Tradeoffs / breaking changes

- **`pip install tinyros[portal]` / `pip install tinyros[dev]` no longer work.** Contributors should use `uv sync --group dev` (and `--group benchmark` for the comparison benchmarks). Documented in `CONTRIBUTING.md`.
- Author email switched from `aterpin@ethz.ch` to `antonio.terpin@gmail.com` to match git authorship on recent commits. If you'd rather keep the ethz email, say so and I'll flip it back.

## Test plan

- [x] `uv sync --group dev` resolves cleanly.
- [x] `uv run pre-commit run --all-files` passes (incl. bandit).
- [x] `uv run pytest` passes (94 passed, coverage 84.52%).
- [x] `uv build` + `uv run twine check dist/*` pass.
- [x] Wheel inspection: ships `tinyros/py.typed`, `Provides-Extra: logging` only, `License-Expression: MIT`.

Closes #79.
