### PR TITLE
ci(tests): add pytest + basedpyright workflow with 3.10/3.11/3.12 matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+    push:
+        branches:
+            - '**'
+
+jobs:
+    tests:
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: ['3.10', '3.11', '3.12']
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v6
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  enable-cache: true
+
+            - name: Install dependencies
+              run: uv sync --group dev
+
+            - name: Run pytest
+              run: uv run pytest
+
+            - name: Run basedpyright
+              run: uv run basedpyright src tests


### PR DESCRIPTION
## Summary

- Add `.github/workflows/tests.yaml` so pytest and basedpyright actually run in CI.
- Matrix on Python 3.10, 3.11, 3.12.
- Uses `astral-sh/setup-uv` to match the local toolchain.

## Why

Today CI only runs `code-style.yaml` (pre-commit) and `commit-lint.yaml`. The pytest pre-commit hook is staged at `pre-push`, which never fires in CI — so test correctness was only verified locally.

## Depends on

**PR #82 (#79 packaging cleanup).** This workflow uses `uv sync --group dev`. Today on `main`, dev tooling lives in `[project.optional-dependencies].dev`; only after #82 is everything in `[dependency-groups].dev`. Merge #82 first; this PR's CI will go green once that lands.

## Test plan

- [x] `uv run pre-commit run --all-files` passes (lint/format on the new YAML).
- [ ] CI matrix green on 3.10 / 3.11 / 3.12 (verify post-merge of #82).

Closes #74.
