### PR TITLE
ci(release): add tag-triggered PyPI publish + GitHub Release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+    push:
+        tags:
+            - 'v*'
+
+permissions:
+    contents: write   # gh release create
+    id-token: write   # PyPI OIDC trusted publishing
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        # Scope the OIDC token to the `pypi` GitHub environment so the
+        # PyPI trusted-publisher claim can pin to it. Configure the
+        # environment + the matching trusted publisher on PyPI before
+        # the first release.
+        environment:
+            name: pypi
+            url: https://pypi.org/p/tinyros
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0   # full history -> previous-tag lookup
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v6
+              with:
+                  python-version: '3.12'
+
+            - name: Verify tag matches pyproject.toml version
+              run: |
+                  TAG="${GITHUB_REF#refs/tags/}"
+                  TAG_VERSION="${TAG#v}"
+                  PYPROJECT_VERSION=$(
+                      awk -F'"' '/^version = /{print $2; exit}' pyproject.toml
+                  )
+                  if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+                      echo "::error::Tag $TAG ($TAG_VERSION) does not match pyproject.toml version ($PYPROJECT_VERSION)"
+                      exit 1
+                  fi
+                  echo "Tag $TAG matches pyproject.toml version $PYPROJECT_VERSION"
+
+            - name: Build distribution
+              run: uv build
+
+            - name: Verify metadata with twine
+              run: uv run --with twine twine check dist/*
+
+            - name: Publish to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+
+            - name: Create GitHub Release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  TAG="${GITHUB_REF#refs/tags/}"
+                  PREV_TAG=$(
+                      git tag --sort=-v:refname \
+                          | grep -A1 "^${TAG}$" \
+                          | tail -n1
+                  )
+                  if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$TAG" ]; then
+                      gh release create "$TAG" \
+                          --title "$TAG" \
+                          --generate-notes \
+                          --notes-start-tag "$PREV_TAG"
+                  else
+                      gh release create "$TAG" \
+                          --title "$TAG" \
+                          --generate-notes
+                  fi

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -1,0 +1,68 @@
+# Releasing TinyROS
+
+This page documents how a release is cut. The mechanics are automated by
+[`.github/workflows/release.yaml`](../../.github/workflows/release.yaml);
+this guide covers the human steps before and after.
+
+## One-time setup (per maintainer)
+
+1. **PyPI trusted publisher.** On
+   [PyPI -> tinyros -> Publishing](https://pypi.org/manage/project/tinyros/settings/publishing/),
+   add a *trusted publisher* with:
+    - Owner: `antonioterpin`
+    - Repository: `tinyros`
+    - Workflow filename: `release.yaml`
+    - Environment name: `pypi`
+
+2. **GitHub environment.** On the repo -> Settings -> Environments,
+   create an environment named `pypi`. Optionally restrict deployments
+   to protected branches and require manual approval.
+
+Once both are configured, no PyPI API token is ever stored in the repo
+or in a GitHub secret -- short-lived OIDC tokens authorize each publish.
+
+## Cutting a release
+
+```sh
+# 1. Bump pyproject.toml version on a release branch.
+git checkout -b release/X.Y.Z
+$EDITOR pyproject.toml   # bump `version = "X.Y.Z"`
+git commit -am "release: X.Y.Z"
+
+# 2. Open and merge the release PR.
+gh pr create --title "release: X.Y.Z" --body "..."
+
+# 3. Tag main once the release PR has merged.
+git checkout main
+git pull
+git tag -a vX.Y.Z -m "tinyros X.Y.Z"
+git push origin vX.Y.Z
+```
+
+Pushing the tag triggers `release.yaml`, which:
+
+1. Verifies the tag matches `pyproject.toml`'s `version` (fails fast if
+   they drift).
+2. Builds the sdist and wheel with `uv build`.
+3. Runs `twine check` on the built artifacts.
+4. Publishes to PyPI via OIDC trusted publishing.
+5. Creates the GitHub Release with auto-generated notes scoped to the
+   commit range since the previous tag.
+
+## After the release
+
+- Confirm the release shows on
+  [PyPI](https://pypi.org/project/tinyros/) and
+  [GitHub Releases](https://github.com/antonioterpin/tinyros/releases).
+- If anything failed, the workflow can be re-run from
+  *Actions -> Release -> Re-run all jobs* once the underlying issue
+  (e.g. PyPI version conflict, missing trusted publisher config) is
+  resolved. There is no need to re-tag.
+
+## Why the tag is the trigger
+
+The tag is the single source-of-truth artifact for a release: it is
+immutable, reviewable on `git log`, and naturally aligned with both the
+PyPI version and the GitHub Release. `pyproject.toml` is bumped on a
+regular PR like any other change; the tag is the event that says "this
+commit is the release."

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ Single source of truth for all TinyROS documentation. Start here.
 | [agent-development.md](guides/agent-development.md) | Using TinyROS with Claude Code, Antigravity, and custom agents |
 | [troubleshooting.md](guides/troubleshooting.md) | Common operational failure modes (stuck nodes, leaked shm, port reuse) and how to fix them |
 | [benchmarks.md](guides/benchmarks.md) | TinyROS / portal / ROS 2 benchmark suites: install, design notes, run commands |
+| [release.md](guides/release.md) | Cutting a release: tag-driven PyPI publish + GitHub Release |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yaml`: tag-triggered (`v*`) workflow that verifies tag/version parity, builds, publishes to PyPI via OIDC, and creates the GitHub Release.
- Add `docs/guides/release.md` documenting the per-release flow + the one-time PyPI trusted-publisher / GitHub environment setup.
- Link the new doc from `docs/index.md`.

## Why

v0.4.1 went to PyPI but the GitHub Release was missing for days. The version in `pyproject.toml` was stale at the time, indicating the publish leaned on an ad-hoc step. This workflow makes the release deterministic and replayable.

## Required setup before first run

1. On PyPI -> tinyros -> Publishing, register a trusted publisher: owner `antonioterpin`, repo `tinyros`, workflow filename `release.yaml`, environment name `pypi`.
2. On the repo -> Settings -> Environments, create the `pypi` environment.

Both are documented in `docs/guides/release.md`. Without them, the publish step fails (the rest of the workflow still runs, so the failure is loud and isolated).

## Test plan

- [x] `uv run pre-commit run --all-files` passes (yaml + bandit + linters).
- [ ] First real-world test will be the next tag push; the workflow short-circuits on tag/version mismatch so a misaligned tag fails before any external side effect.

Closes #76.

Related: PR #81 (importlib.metadata version single-source) — once both land, future releases need only a `pyproject.toml` bump and a tag push.
