### PR TITLE
refactor(transport): raise on duplicate TinyServer.bind, fix stale doc

### DIFF
--- a/docs/guides/architecture/overview.md
+++ b/docs/guides/architecture/overview.md
@@ -56,9 +56,10 @@ by name.
 
 ### Transport
 
-`TinyTransport` provides the RPC plumbing under `TinyNode`. Each node owns
-a `TinyServer` (accepts inbound calls) and may own any number of
-`TinyClient`s (makes outbound calls to other nodes).
+The `tinyros.transport` package provides the RPC plumbing under
+`TinyNode`. Each node owns a `TinyServer` (accepts inbound calls) and
+may own any number of `TinyClient`s (makes outbound calls to other
+nodes).
 
 See [`transport.md`](transport.md) for the wire protocol, framing, and
 the shared-memory fast path for large numpy payloads.

--- a/src/tinyros/transport/_server.py
+++ b/src/tinyros/transport/_server.py
@@ -133,6 +133,10 @@ class TinyServer:
         Raises:
             RuntimeError: If called after :meth:`start` (the server is
                 already accepting connections).
+            ValueError: If ``name`` is already bound. Re-binding silently
+                hides typos that happen to collide with an existing
+                callback name; callers that truly want to replace a
+                binding must drop the prior one explicitly.
         """
         with self._state_lock:
             if self._started:
@@ -140,6 +144,12 @@ class TinyServer:
                     f"{self.name}: bind({name!r}, ...) called after "
                     f"start(); register all callbacks before starting "
                     f"the server"
+                )
+            if name in self._callbacks:
+                raise ValueError(
+                    f"{self.name}: bind({name!r}, ...) called twice; "
+                    f"the existing binding would be silently overwritten. "
+                    f"Drop one of the bind() calls."
                 )
             self._callbacks[name] = fn
 

--- a/tests/test_transport_rpc.py
+++ b/tests/test_transport_rpc.py
@@ -223,6 +223,23 @@ def test_bind_after_start_raises(free_port: int) -> None:
         wait_port_free(free_port)
 
 
+def test_bind_duplicate_name_raises(free_port: int) -> None:
+    """Binding the same name twice must fail loudly.
+
+    Silent overwrite hides typos that collide with an existing callback
+    name (e.g. two topics in the network config accidentally pointing
+    at the same callable name). Force the caller to be explicit.
+    """
+    server = TinyServer(name="t-bind-dup", host="127.0.0.1", port=free_port)
+    server.bind("noop", lambda x: x)
+    try:
+        with pytest.raises(ValueError, match="called twice"):
+            server.bind("noop", lambda x: x)
+    finally:
+        server.close(timeout=1.0)
+        wait_port_free(free_port)
+
+
 def test_server_bounded_inflight(free_port: int) -> None:
     """The server honours ``max_in_flight`` -- backpressure caps the
     number of simultaneously running/queued calls.


### PR DESCRIPTION
## Summary

Two cleanup items from the original #78 punch list. The other four were already addressed on `main` (or are picked up by sibling PRs in this train) — see "Already done" below.

### Changes

- **`TinyServer.bind` raises on duplicate name** (`src/tinyros/transport/_server.py`). Silent overwrite hid typos that collided with an existing callback name (e.g. two topics in the network config pointing at the same callable name). New behavior: second `bind("foo", ...)` raises `ValueError`. Regression test in `tests/test_transport_rpc.py::test_bind_duplicate_name_raises`.
- **`docs/guides/architecture/overview.md` no longer references a nonexistent `TinyTransport` class.** Rephrased to describe the `tinyros.transport` package.

### Already done on `main` (no work in this PR)

- `TinyNode._setup_subscriptions` raises on missing/non-callable callback (`src/tinyros/node.py:354-366`).
- `TinyNode.publish` keeps the futures list aligned with `topic_calls` (`src/tinyros/node.py:401-412`).
- `README.md` does not actually contain the "TinyROS relies on portal" claim my audit pointed at — only a benign benchmark mention.

### Picked up by sibling PRs

- `CONTRIBUTING.md` "Python 3.11+ / JAX/Flax" claim — fixed in PR #82 (#79 packaging cleanup).

## Test plan

- [x] `uv run pytest` (95 passed, +1 vs main, 89 skipped, coverage 84.5%).
- [x] `uv run pre-commit run --all-files` passes.

Closes #78.
