### PR TITLE
ci(security): add SECURITY/CODEOWNERS, dependabot, CodeQL, audit, benchmarks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo. Add more specific entries
+# above this line if/when sub-areas get dedicated reviewers.
+* @antonioterpin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 5
+
+    - package-ecosystem: pip
+      directory: /
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 5

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,34 @@
+name: Dependency audit
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+    schedule:
+        - cron: '0 7 * * 1'   # Monday 07:00 UTC
+
+permissions:
+    contents: read
+
+jobs:
+    pip-audit:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v6
+              with:
+                  python-version: '3.12'
+
+            - name: Export runtime dependency tree
+              run: |
+                  uv export --no-hashes --no-dev \
+                      --format requirements-txt \
+                      > /tmp/runtime-requirements.txt
+
+            - name: Run pip-audit
+              run: uvx pip-audit --requirement /tmp/runtime-requirements.txt

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,36 @@
+name: Benchmarks
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '0 5 * * 0'   # Sunday 05:00 UTC
+
+permissions:
+    contents: read
+
+jobs:
+    benchmarks:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v6
+              with:
+                  python-version: '3.12'
+                  enable-cache: true
+
+            - name: Install dependencies (dev + benchmark)
+              run: uv sync --group dev --group benchmark
+
+            # The ros2 directory is excluded via `norecursedirs` in
+            # pyproject.toml; running the others is enough to catch
+            # bitrot in the tinyros and portal benchmark code paths.
+            - name: Run benchmarks
+              run: |
+                  uv run pytest \
+                      -m run_explicitly \
+                      tests/benchmark/tinyros \
+                      tests/benchmark/portal

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+    schedule:
+        - cron: '0 6 * * 1'   # Monday 06:00 UTC
+
+permissions:
+    actions: read
+    contents: read
+    security-events: write
+
+jobs:
+    analyze:
+        name: Analyze (Python)
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                  languages: python
+                  queries: security-extended
+
+            - name: Perform analysis
+              uses: github/codeql-action/analyze@v3
+              with:
+                  category: "/language:python"

--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -10,7 +10,7 @@ jobs:
                 runs-on: ubuntu-latest
                 steps:
                         - name: Checkout code
-                          uses: actions/checkout@v3
+                          uses: actions/checkout@v4
                         - name: Run Commitlint
                           uses: wagoid/commitlint-github-action@v5
                           with:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.4.x   | yes       |
+| < 0.4   | no        |
+
+## Reporting a vulnerability
+
+Please report security issues privately to **antonio.terpin@gmail.com**.
+
+If the issue is in the RPC transport (`tinyros.transport`), include:
+
+- a minimal reproduction (network config + sequence of calls);
+- whether the trigger requires only a localhost peer or non-loopback
+  network access;
+- the tinyros version
+  (`python -c "import tinyros; print(tinyros.__version__)"`).
+
+The maintainer will acknowledge receipt within 7 days and aim to ship a
+fix and a coordinated disclosure within 30 days for confirmed issues.
+Public discussion happens after a fix is released.
+
+## Threat model snapshot
+
+- The RPC server uses `pickle.loads` on incoming frames, so any peer
+  that can connect to a server has effective code-execution authority.
+  Bind to loopback unless every peer is fully trusted; non-loopback
+  binds emit a warning.
+- The shared-memory fast path uses POSIX shm names with no
+  authentication; the same trust model applies.
+
+These limits are documented behavior of the current transport and are
+not themselves vulnerabilities under this policy. Bypasses of those
+limits (e.g. crashing the server from a peer that should be benign,
+escaping the configured frame-size cap) are in scope.


### PR DESCRIPTION
## Summary

Six supply-chain hardening additions plus a stale-action bump. All independent of each other; bundled because they're the same theme.

### What's added

- **`SECURITY.md`** — vulnerability-disclosure email, supported-versions table, threat-model snapshot calling out the pickle-based RPC trust model so reporters know what's in scope.
- **`.github/CODEOWNERS`** — default ownership routes PR reviews automatically.
- **`.github/dependabot.yml`** — weekly bumps for `github-actions` and the `pip` ecosystem.
- **`.github/workflows/codeql.yaml`** — standard Python CodeQL on push/PR to main, plus Monday cron.
- **`.github/workflows/audit.yaml`** — `pip-audit` against the runtime tree (`uv export --no-dev`) on push/PR/weekly cron. The pickle-loads RPC surface is the project's biggest known supply-chain risk, so catching CVEs in runtime deps matters more than the small dep count would suggest.
- **`.github/workflows/benchmarks.yaml`** — weekly + manual `pytest -m run_explicitly` for tinyros and portal benchmarks so they don't silently bitrot. (Depends on PR #82 for `uv sync --group benchmark`.)
- **`commit-lint.yaml`**: `actions/checkout@v3` → `@v4` (already at v4 in `code-style.yaml`).

### Already done on `main` (no work in this PR)

- **Bandit**: already wired in `.pre-commit-config.yaml` and `[tool.bandit]` in `pyproject.toml`.
- **`commitlint.config.js` missing**: stale audit — the file exists at repo root.

## Required setup

- **Dependabot**: enable on the repo if not already (Settings → Code security → Dependabot alerts/security updates).
- **CodeQL**: code-scanning needs to be enabled at the repo level for the workflow to upload results.

## Test plan

- [x] `uv run pre-commit run --all-files` passes (incl. yaml + bandit).
- [x] CodeQL job goes green on first push.
- [x] Audit job either reports clean or surfaces real CVEs (fine outcome).
- [x] Benchmarks job runs successfully on the next Sunday cron (depends on #82 merging first).

Closes #80.
