### PR TITLE
ci(commitlint): migrate config to .mjs

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -14,4 +14,4 @@ jobs:
                         - name: Run Commitlint
                           uses: wagoid/commitlint-github-action@v5
                           with:
-                                configFile: commitlint.config.js
+                                configFile: commitlint.config.mjs

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [


### PR DESCRIPTION
## Summary
- Rename `commitlint.config.js` → `commitlint.config.mjs` (convert `module.exports` to ESM `export default`).
- Update `.github/workflows/commit-lint.yaml` to reference the `.mjs` file.

## Why
[wagoid/commitlint-github-action v6](https://github.com/wagoid/commitlint-github-action/releases/tag/v6.0.0) dropped support for `.js` config files and now errors with:

```
.js extension is not allowed for the configFile, please use .mjs instead
```

This caused the commit-lint check to fail on dependabot PR #89 (v5 → v6 bump). Landing this first makes that PR a clean rebase. The `.mjs` config also still works with the current v5 action, so this PR is safe to merge on its own.

## Test plan
- [ ] CI: `commit-lint` job passes against the renamed config on this branch.
- [ ] After merge, rebase #89 and confirm it goes green on v6.