### PR TITLE
ci(commitlint): ignore dependabot commits

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,5 +1,6 @@
 export default {
   extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => /^Signed-off-by: dependabot\[bot\]/m.test(message)],
   rules: {
     'type-enum': [
       2,


### PR DESCRIPTION
## Summary
- Add an `ignores` filter to `commitlint.config.mjs` that skips commits signed off by `dependabot[bot]`.

## Why
The default `body-max-line-length: 100` from `@commitlint/config-conventional` fails on dependabot commits because their bodies always include long markdown links from upstream changelogs/release notes (e.g. PR #89 commit-lint failure: "body's lines must not be longer than 100 characters").

Skipping dependabot commits is preferred over disabling the rule globally, since human-authored commits still benefit from the wrap.

## Test plan
- [x] Local: `uv run pre-commit run --all-files` passes (it does).
- [x] On merge: PR #89 commit-lint goes green (after rebase).
- [x] Future dependabot PRs no longer trip the body-line-length rule.
