### PR TITLE
release: 0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyros"
-version = "0.4.1"
+version = "0.4.2"
 description = "A minimal operating system for robotics."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3087,7 +3087,7 @@ wheels = [
 
 [[package]]
 name = "tinyros"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Version bump from `0.4.1` → `0.4.2`. Two-line change: `pyproject.toml` + the matching `tinyros` entry in `uv.lock`.

## Why now

This release is the first real exercise of the tag-driven publish pipeline added in #84. After this PR merges, pushing tag `v0.4.2` will trigger [release.yaml](./.github/workflows/release.yaml), which:

1. Verifies the tag matches `pyproject.toml`'s version (fails fast if they drift).
2. Builds sdist + wheel via `uv build`.
3. Runs `twine check`.
4. Publishes to PyPI via OIDC trusted publishing (no API tokens stored in the repo).
5. Creates the GitHub Release with auto-generated notes scoped to commits since `v0.4.1`.

If the PyPI trusted-publisher / `pypi` GitHub environment isn't configured yet, the *publish* step fails — but the verify + build + twine-check steps still run, so any tag/version drift would surface before any external side effect.

## What's in 0.4.2

Highlights since `v0.4.1` — full notes will be auto-generated by the release workflow.

- **CI matrix** — pytest + basedpyright on Python 3.10/3.11/3.12 (#83).
- **Supply-chain hardening** — SECURITY.md, CODEOWNERS, Dependabot, CodeQL, pip-audit, benchmark workflow (#86).
- **Tag-driven release pipeline** — OIDC trusted publishing + GitHub Release automation (#84).
- **Packaging modernization** — `pyproject.toml` cleanup, dev/benchmark dependency groups (#82).
- **Single-source `__version__`** — derived from package metadata via `importlib.metadata` (#81).
- **API + docs cleanup** — `TinyServer.bind` raises on duplicates (#85).
- **Commitlint v6 migration** — config moved to `.mjs` (#92), Dependabot commits ignored (#94).

## Test plan

- [x] `pre-commit run --files pyproject.toml uv.lock` passes.
- [x] After merge: tag `v0.4.2` on main and push; verify `release.yaml` succeeds end-to-end.
- [x] Confirm release on [PyPI](https://pypi.org/project/tinyros/) and [GitHub Releases](https://github.com/antonioterpin/tinyros/releases).
