### PR TITLE
ci(benchmarks): disable coverage gate for benchmark job

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -28,9 +28,16 @@ jobs:
             # The ros2 directory is excluded via `norecursedirs` in
             # pyproject.toml; running the others is enough to catch
             # bitrot in the tinyros and portal benchmark code paths.
+            #
+            # --no-cov overrides the global --cov-fail-under=80 from
+            # pyproject.toml: that gate is for the full suite in tests.yaml.
+            # This subset only exercises speed paths (and GPU cases skip on a
+            # GPU-less runner), so it can't reach 80%. Coverage instrumentation
+            # would also distort the timing measurements.
             - name: Run benchmarks
               run: |
                   uv run pytest \
+                      --no-cov \
                       -m run_explicitly \
                       tests/benchmark/tinyros \
                       tests/benchmark/portal


### PR DESCRIPTION
## Problem

The scheduled **Benchmarks** workflow [failed](https://github.com/antonioterpin/tinyros/actions/runs/25984833877) even though every test passed (`23 passed, 66 skipped`). It died solely on the global coverage gate:

```
FAIL Required test coverage of 80% not reached. Total coverage: 62.59%
```

`pyproject.toml` applies `--cov=src --cov-fail-under=80` via `[tool.pytest.ini_options].addopts`, so it hits *every* `pytest` invocation. That gate is meant for the full suite in `tests.yaml`. The benchmark job only runs the speed subset (`tests/benchmark/{tinyros,portal}`), and the GPU cases skip on a GPU-less GitHub runner, so coverage is structurally ~63%.

## Fix

Pass `--no-cov` for the benchmark run. Beyond unblocking CI, this is correct on the merits: coverage instrumentation adds per-line overhead that distorts the timing measurements a benchmark exists to produce, so it should never be enabled here.

Verified locally that `--no-cov`:
- is accepted on top of the global `addopts`,
- does not trip `filterwarnings = ["error"]` (pytest-cov's disable warning is not promoted to an error),
- makes the run exit `0` despite low coverage.

Only the scheduled `Benchmarks` workflow is affected; `tests.yaml` keeps its 80% gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)